### PR TITLE
Add the rustywind library to sort Tailwind CSS class names.

### DIFF
--- a/app/views/accounts/new.html.erb
+++ b/app/views/accounts/new.html.erb
@@ -1,5 +1,5 @@
-<main class="w-screen py-12 lg:p-12 lg:min-h-screen lg:flex">
-  <div class="self-center w-full max-w-lg px-8 py-12 mx-auto">
+<main class="py-12 w-screen lg:flex lg:p-12 lg:min-h-screen">
+  <div class="self-center py-12 px-8 mx-auto w-full max-w-lg">
     <div class="mb-12 text-center">
       <h1 class="text-3xl font-bold text-gray-700"><%= t(".header") %></h1>
     </div>
@@ -21,7 +21,7 @@
         <% end %>
       </div>
 
-      <button class="block w-4/5 p-4 mx-auto mt-6 text-lg font-semibold text-center text-white bg-green-600 rounded-lg focus:outline-none hover:bg-green-500 focus:shadow-green-200" type="submit">
+      <button class="block p-4 mx-auto mt-6 w-4/5 text-lg font-semibold text-center text-white bg-green-600 rounded-lg hover:bg-green-500 focus:outline-none focus:shadow-green-200" type="submit">
         <%= t(".submit") %>
       </button>
     <% end %>

--- a/app/views/characters/index.html.erb
+++ b/app/views/characters/index.html.erb
@@ -1,5 +1,5 @@
-<main class="w-screen py-12 lg:p-12">
-  <div class="w-full max-w-lg px-8 py-12 mx-auto">
+<main class="py-12 w-screen lg:p-12">
+  <div class="py-12 px-8 mx-auto w-full max-w-lg">
     <div class="mb-12 text-center">
       <h1 class="text-3xl font-bold text-gray-700"><%= t(".header") %></h1>
     </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US" class="text-gray-900 antialiased">
+<html lang="en-US" class="antialiased text-gray-900">
 <head>
   <meta name="viewport" content="width=device-width, initial-scale=1">
 

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -1,4 +1,4 @@
-<main class="container w-3/4 my-16 mx-auto text-center">
+<main class="container my-16 mx-auto w-3/4 text-center">
   <header>
     <h1 class="text-4xl font-bold tracking-tight"><%= t("title") %></h1>
   </header>

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "miroha",
   "private": true,
   "scripts": {
+    "fix:html": "rustywind --write app/views",
     "lint": "eslint app config spec/javascripts *.js",
     "lint:css": "stylelint app/assets/stylesheets/**/*.scss",
     "test": "NODE_ENV=test NODE_PATH=app/assets/javascripts mocha --config spec/javascripts/mocharc.js spec/javascripts",
@@ -34,6 +35,7 @@
     "mocha": "9.1.1",
     "mocha-yaml-loader": "1.0.3",
     "nyc": "15.1.0",
+    "rustywind": "0.12.2",
     "sinon": "11.1.2",
     "sinon-chai": "3.7.0",
     "stylelint": "13.13.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1434,6 +1434,11 @@ adjust-sourcemap-loader@^4.0.0:
     loader-utils "^2.0.0"
     regex-parser "^2.2.11"
 
+agent-base@5:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-5.1.1.tgz#e8fb3f242959db44d63be665db7a8e739537a32c"
+  integrity sha512-TMeqbNl2fMW0nMjTEPOwe3J/PRFP4vqeoNuQMG0HlMrtm5QxKqdvAkZ1pRBQ/ulIyDD5Yq0nJ7YbdD8ey0TO3g==
+
 agent-base@6:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-6.0.2.tgz#49fff58577cfee3f37176feab4c22e00f86d7f77"
@@ -4339,6 +4344,14 @@ https-browserify@^1.0.0:
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
   integrity sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=
 
+https-proxy-agent@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-4.0.0.tgz#702b71fb5520a132a66de1f67541d9e62154d82b"
+  integrity sha512-zoDhWrkR3of1l9QAL8/scJZyLu8j/gBkcwcaQOZh7Gyh/+uJQzGVETdgT30akuwkpL8HTRfssqI3BZuV18teDg==
+  dependencies:
+    agent-base "5"
+    debug "4"
+
 https-proxy-agent@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz#e2a90542abb68a762e0a0850f6c9edadfd8506b2"
@@ -7217,6 +7230,11 @@ proxy-addr@~2.0.5:
     forwarded "0.2.0"
     ipaddr.js "1.9.1"
 
+proxy-from-env@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
+
 prr@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/prr/-/prr-1.0.1.tgz#d3fc114ba06995a45ec6893f484ceb1d78f5f476"
@@ -7708,6 +7726,14 @@ run-queue@^1.0.0, run-queue@^1.0.3:
   integrity sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=
   dependencies:
     aproba "^1.1.1"
+
+rustywind@0.12.2:
+  version "0.12.2"
+  resolved "https://registry.yarnpkg.com/rustywind/-/rustywind-0.12.2.tgz#ae4f18ae78ed122ef7e338922fe1256bb0ae363c"
+  integrity sha512-mZkjNUsuyrFiLphgKa3mmfi2QLtoepfLLCDvTBMmiPzhNhpps9+vuCv14GPZPlICL0yYChk/CCTVYPGz2M5evQ==
+  dependencies:
+    https-proxy-agent "^4.0.0"
+    proxy-from-env "^1.1.0"
 
 safe-buffer@5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"


### PR DESCRIPTION
Also fixes the existing HTML files.

- Using an editor integration is recommended for fixing, but a `yarn fix:html` script is included for manually fixing.
- This won't cover class names in helpers, so will need to keep an eye out for them. 