### PR TITLE
Run database migrations during the release phase.

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
+release: bundle exec rake db:migrate
 web: bundle exec puma -C config/puma.rb


### PR DESCRIPTION
This will cause the default `foreman start` to fail locally from the migration Rake task exiting, but it shouldn't be an issue since `foreman start -f Procfile.dev` is the recommended solution in development.