### PR TITLE
Only trigger CI on pushes to main or pull requests.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   Build:


### PR DESCRIPTION
Helps prevent duplicate runs when pushing to a pull request.