### PR TITLE
Remove an invalid punctuation character from the emote command.

### DIFF
--- a/app/services/commands/emote_command.rb
+++ b/app/services/commands/emote_command.rb
@@ -3,7 +3,7 @@
 module Commands
   class EmoteCommand < Base
     DEFAULT_PUNCTUATION    = "."
-    PUNCTUATION_CHARACTERS = %w(. ? ! " ... …).freeze
+    PUNCTUATION_CHARACTERS = %w(. ? ! " …).freeze
     PUNCTUATION_MATCHER    = /[#{PUNCTUATION_CHARACTERS.join}]\z/
 
     # Broadcast an emote command to chat.


### PR DESCRIPTION
Since the options are treated as single characters the set of three periods are treated as three separate characters. Also, with a single period treated as punctuation already, any number of periods can end the message and not trigger the default punctuation.