### PR TITLE
Move the game rendering to a separate controller.

### DIFF
--- a/app/controllers/game_controller.rb
+++ b/app/controllers/game_controller.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class GameController < ApplicationController
+  layout "game"
+
+  rescue_from ActiveRecord::RecordNotFound do
+    redirect_to characters_url
+  end
+
+  # Render the game.
+  def index
+    @character = Character.includes(:room).find(session[:character_id])
+  end
+end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,10 +1,4 @@
 # frozen_string_literal: true
 
 class PagesController < ApplicationController
-  # Render the homepage, or the game if a character is present.
-  def index
-    if current_character?
-      render "game/index", layout: "game"
-    end
-  end
 end

--- a/app/views/game/_sidebar.html.erb
+++ b/app/views/game/_sidebar.html.erb
@@ -1,4 +1,4 @@
 <div id="sidebar" class="grid bg-gray-900">
-  <%= render "game/sidebar/character" %>
+  <%= render "game/sidebar/character", character: character %>
   <%= render "game/sidebar/navigation" %>
 </div>

--- a/app/views/game/_streams.html.erb
+++ b/app/views/game/_streams.html.erb
@@ -1,4 +1,4 @@
 <div id="streams">
-  <%= turbo_stream_from current_character %>
-  <%= turbo_stream_from current_character.room %>
+  <%= turbo_stream_from character %>
+  <%= turbo_stream_from character.room %>
 </div>

--- a/app/views/game/index.html.erb
+++ b/app/views/game/index.html.erb
@@ -1,12 +1,12 @@
 <main class="h-screen" data-controller="game">
   <div id="container" class="grid h-full">
-    <%= render "game/sidebar" %>
+    <%= render "game/sidebar", character: @character %>
     <%= render "game/chat" %>
     <%= render "game/surroundings" %>
   </div>
 </main>
 
-<%= render "game/streams" %>
+<%= render "game/streams", character: @character %>
 
 <% content_for(:head) do %>
   <script type="text/javascript">

--- a/app/views/game/sidebar/_character.html.erb
+++ b/app/views/game/sidebar/_character.html.erb
@@ -1,14 +1,14 @@
-<div class="relative h-1 bg-yellow-900" title="<%= t(".experience", remaining: number_with_delimiter(current_character.experience.remaining)) %>">
-  <div class="absolute inset-0 h-full bg-yellow-600" style="width: <%= current_character.experience.remaining_percentage %>%;"></div>
+<div class="relative h-1 bg-yellow-900" title="<%= t(".experience", remaining: number_with_delimiter(character.experience.remaining)) %>">
+  <div class="absolute inset-0 h-full bg-yellow-600" style="width: <%= character.experience.remaining_percentage %>%;"></div>
 </div>
 
 <div class="p-4 bg-gray-900">
   <div>
     <h1 class="float-left text-xl font-medium leading-none text-gray-300">
-      <%= current_character.name %>
+      <%= character.name %>
     </h1>
     <h2 class="float-right mt-1 text-sm leading-none text-gray-500">
-      <%= t(".level", level: current_character.level) %>
+      <%= t(".level", level: character.level) %>
     </h2>
   </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,5 +16,9 @@ Rails.application.routes.draw do
   resources :commands, only: %i(create)
   resource  :sessions, only: %i(new create destroy)
 
+  constraints(->(request) { Constraints::Game.matches?(request) }) do
+    root to: "game#index", as: :game_root
+  end
+
   root to: "pages#index"
 end

--- a/lib/constraints/game.rb
+++ b/lib/constraints/game.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Constraints
+  class Game
+    # Determine if the request has access to the game.
+    #
+    # @return [Boolean]
+    def self.matches?(request)
+      request.session[:character_id].present?
+    end
+  end
+end

--- a/spec/controllers/game_controller_spec.rb
+++ b/spec/controllers/game_controller_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe GameController, type: :controller do
+  describe "#index", type: :controller do
+    context "with a valid character ID" do
+      let(:character) { create(:character) }
+
+      before do
+        sign_in_as character
+
+        get :index
+      end
+
+      it { is_expected.to respond_with(200) }
+      it { is_expected.to render_template("game/index", layout: "game") }
+
+      it "assigns the current character" do
+        expect(assigns(:character)).to eq(character)
+      end
+    end
+
+    context "with an invalid character ID" do
+      before do
+        get :index
+      end
+
+      it { is_expected.to redirect_to(characters_url) }
+    end
+  end
+end

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -4,26 +4,11 @@ require "rails_helper"
 
 describe PagesController, type: :controller do
   describe "#index", type: :controller do
-    context "without a current character" do
-      before do
-        get :index
-      end
-
-      it { is_expected.to respond_with(200) }
-      it { is_expected.to render_template(:index) }
+    before do
+      get :index
     end
 
-    context "with a current character" do
-      let(:character) { create(:character) }
-
-      before do
-        sign_in_as character
-
-        get :index
-      end
-
-      it { is_expected.to respond_with(200) }
-      it { is_expected.to render_template("game/index", layout: "game") }
-    end
+    it { is_expected.to respond_with(200) }
+    it { is_expected.to render_template(:index) }
   end
 end

--- a/spec/lib/constraints/game_spec.rb
+++ b/spec/lib/constraints/game_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe Constraints::Game do
+  describe ".matches?" do
+    subject { described_class.matches?(request) }
+
+    let(:request) do
+      instance_double(ActionDispatch::Request, session: session)
+    end
+
+    context "with a character ID in the session" do
+      let(:session) { { character_id: SecureRandom.uuid } }
+
+      it { is_expected.to eq(true) }
+    end
+
+    context "without a character ID in the session" do
+      let(:session) { {} }
+
+      it { is_expected.to eq(false) }
+    end
+  end
+end

--- a/spec/views/game/_sidebar.html_spec.rb
+++ b/spec/views/game/_sidebar.html_spec.rb
@@ -4,10 +4,13 @@ require "rails_helper"
 
 describe "game/_sidebar.html.erb", type: :view do
   subject(:html) do
-    render
+    render partial: "game/sidebar",
+           locals:  { character: character }
 
     rendered
   end
+
+  let(:character) { build_stubbed(:character) }
 
   before do
     stub_template(

--- a/spec/views/game/_streams.html_spec.rb
+++ b/spec/views/game/_streams.html_spec.rb
@@ -4,7 +4,8 @@ require "rails_helper"
 
 describe "game/_streams.html.erb", type: :view do
   subject(:html) do
-    render partial: "game/streams", locals: { current_character: character }
+    render partial: "game/streams",
+           locals:  { character: character }
 
     rendered
   end

--- a/spec/views/game/sidebar/_character.html_spec.rb
+++ b/spec/views/game/sidebar/_character.html_spec.rb
@@ -6,7 +6,7 @@ describe "game/sidebar/_character.html.erb", type: :view do
   subject(:html) do
     render(
       partial: "game/sidebar/character",
-      locals:  { current_character: character }
+      locals:  { character: character }
     )
 
     rendered


### PR DESCRIPTION
This separates the game rendering into a separate controller and manually finds the current character instead of using the authentication concern.

Manually finding the character is important to allow including associations, especially as surrounding characters are added. It could make sense to add a `current_character_scope` to the authentication concern, but this is likely to be the only usage for now. As a result, the views have also been updated to use the manually found character.

With the addition of the specific query and error handling, with the assumption more will happen in the future, the game was moved to a separate controller. A routing constraint is used to keep using the root path for playing the game.