### PR TITLE
Require an active character to play the game.

### DIFF
--- a/app/assets/javascripts/controllers/chat_controller.js
+++ b/app/assets/javascripts/controllers/chat_controller.js
@@ -35,6 +35,20 @@ export default class ChatController extends Controller {
   }
 
   /**
+   * Handle redirect responses.
+   *
+   * @param {Event} event The submit event.
+   * @return {void}
+   */
+  handleRedirect(event) { // eslint-disable-line class-methods-use-this
+    const { redirected, url } = event.detail.fetchResponse.response;
+
+    if (redirected) {
+      window.location = url;
+    }
+  }
+
+  /**
    * Scroll to the bottom when a message is connected.
    *
    * @param {Event} event The dispatched event.

--- a/app/controllers/commands_controller.rb
+++ b/app/controllers/commands_controller.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
 class CommandsController < ApplicationController
-  before_action :authenticate
-  before_action :require_character
+  before_action :authenticate, :require_active_character
   after_action :mark_character_as_active
 
   rescue_from ActionController::ParameterMissing do

--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -89,11 +89,15 @@ module Authentication
     current_character.present?
   end
 
-  # Redirect to character creation if no character is present.
+  # Redirect if a character is missing or the character is not active.
   #
   # @return [void]
-  def require_character
-    redirect_to new_character_url if current_character.nil?
+  def require_active_character
+    if current_character.nil?
+      redirect_to new_character_url
+    elsif current_character.inactive?
+      redirect_to characters_url
+    end
   end
 
   # Determine if an account is signed in.

--- a/app/controllers/game_controller.rb
+++ b/app/controllers/game_controller.rb
@@ -3,12 +3,23 @@
 class GameController < ApplicationController
   layout "game"
 
+  before_action :require_active_character
+
   rescue_from ActiveRecord::RecordNotFound do
     redirect_to characters_url
   end
 
   # Render the game.
   def index
-    @character = Character.includes(:room).find(session[:character_id])
+    @character = current_character
+  end
+
+  protected
+
+  # Override the current character helper to include other records.
+  #
+  # @return [Character]
+  def current_character
+    @current_character ||= Character.includes(:room).find(session[:character_id])
   end
 end

--- a/app/models/character.rb
+++ b/app/models/character.rb
@@ -28,4 +28,11 @@ class Character < ApplicationRecord
   def experience
     Experience.new(experience: self[:experience], level: self[:level])
   end
+
+  # Return if the character is inactive.
+  #
+  # @return [Boolean]
+  def inactive?
+    active_at < ACTIVE_DURATION.ago
+  end
 end

--- a/app/views/game/chat/_command.html.erb
+++ b/app/views/game/chat/_command.html.erb
@@ -1,5 +1,5 @@
 <%= turbo_frame_tag "command" do %>
-  <%= form_tag commands_path, class: "p-4 bg-gray-200", data: { controller: "chat", action: "submit->chat#aliasCommand submit->chat#validateCommand turbo:submit-end->chat#resetForm" } do %>
+  <%= form_tag commands_path, class: "p-4 bg-gray-200", data: { controller: "chat", action: "submit->chat#aliasCommand submit->chat#validateCommand turbo:submit-end->chat#handleRedirect turbo:submit-end->chat#resetForm" } do %>
     <%= text_field_tag :input, nil, autofocus: true, class: "p-2 w-full text-sm leading-none rounded border border-gray-500 border-solid outline-none focus:border-gray-600", data: { action: "blur->chat#focusCommand", "chat-target": "input" }, spellcheck: false %>
   <% end %>
 <% end %>

--- a/spec/controllers/commands_controller_spec.rb
+++ b/spec/controllers/commands_controller_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 describe CommandsController, type: :controller do
   describe "#create" do
     context "when created successfully" do
-      let(:character) { create(:character, :inactive) }
+      let(:character) { create(:character) }
       let(:input)     { "Hello, world!" }
 
       before do
@@ -55,6 +55,24 @@ describe CommandsController, type: :controller do
         it "marks the character is active", :freeze_time do
           expect(character.reload.active_at).to eq(Time.current)
         end
+      end
+    end
+
+    context "with an inactive character" do
+      let(:character) { create(:character, :inactive) }
+
+      before do
+        allow(Command).to receive(:call)
+
+        sign_in_as character
+
+        post :create, params: { input: "Testing." }
+      end
+
+      it { is_expected.to redirect_to(characters_url) }
+
+      it "does not call the command service" do
+        expect(Command).not_to have_received(:call)
       end
     end
 

--- a/spec/controllers/concerns/authentication_spec.rb
+++ b/spec/controllers/concerns/authentication_spec.rb
@@ -415,7 +415,7 @@ describe Authentication do
     end
   end
 
-  describe "#require_character" do
+  describe "#require_active_character" do
     context "with a character present" do
       let(:character) { build_stubbed(:character) }
 
@@ -425,9 +425,26 @@ describe Authentication do
       end
 
       it "does not call redirect_to" do
-        instance.require_character
+        instance.require_active_character
 
         expect(instance).not_to have_received(:redirect_to)
+      end
+    end
+
+    context "with an inactive character present" do
+      let(:character)      { build_stubbed(:character, :inactive) }
+      let(:characters_url) { double }
+
+      before do
+        allow(instance).to receive(:redirect_to)
+        allow(instance).to receive(:current_character).and_return(character)
+        allow(instance).to receive(:characters_url).and_return(characters_url)
+      end
+
+      it "redirects to characters_url" do
+        instance.require_active_character
+
+        expect(instance).to have_received(:redirect_to).with(characters_url)
       end
     end
 
@@ -441,7 +458,7 @@ describe Authentication do
       end
 
       it "redirects to new_character_url" do
-        instance.require_character
+        instance.require_active_character
 
         expect(instance).to have_received(:redirect_to).with(new_character_url)
       end

--- a/spec/controllers/game_controller_spec.rb
+++ b/spec/controllers/game_controller_spec.rb
@@ -21,6 +21,18 @@ describe GameController, type: :controller do
       end
     end
 
+    context "with an inactive character" do
+      let(:character) { create(:character, :inactive) }
+
+      before do
+        sign_in_as character
+
+        get :index
+      end
+
+      it { is_expected.to redirect_to(characters_url) }
+    end
+
     context "with an invalid character ID" do
       before do
         get :index

--- a/spec/factories/character.rb
+++ b/spec/factories/character.rb
@@ -6,6 +6,8 @@ FactoryBot.define do
     room
     name
 
+    active_at { Time.current }
+
     trait :inactive do
       active_at { Character::ACTIVE_DURATION.ago - 1.minute }
     end

--- a/spec/features/commands/unknown_spec.rb
+++ b/spec/features/commands/unknown_spec.rb
@@ -28,6 +28,14 @@ describe "Sending an unknown command", type: :feature, js: true do
     end
   end
 
+  it "redirects inactive characters" do
+    character.update(active_at: Character::ACTIVE_DURATION.ago - 1.second)
+
+    send_text(command)
+
+    expect(page).to have_text(t("characters.index.header"))
+  end
+
   protected
 
   def have_unknown_command_message(command)

--- a/spec/forms/character_form_spec.rb
+++ b/spec/forms/character_form_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 describe CharacterForm, type: :form do
   subject(:form) do
-    described_class.new(attributes_for(:character).merge(account: account))
+    described_class.new(account: account, name: generate(:name))
   end
 
   let(:account) { create(:account) }

--- a/spec/javascripts/.eslintrc.js
+++ b/spec/javascripts/.eslintrc.js
@@ -1,0 +1,5 @@
+module.exports = {
+  "rules": {
+    "max-lines": "off"
+  }
+};

--- a/spec/javascripts/application/controllers/chat_controller.spec.js
+++ b/spec/javascripts/application/controllers/chat_controller.spec.js
@@ -59,6 +59,58 @@ describe("ChatController", () => {
     });
   });
 
+  context("#handleRedirect", () => {
+    const { location } = window;
+
+    beforeEach(() => {
+      delete window.location;
+
+      window.location = Object.defineProperties(
+        {},
+        {
+          ...Object.getOwnPropertyDescriptors(location),
+          "assign": {
+            "configurable": true,
+            "value": sinon.stub()
+          }
+        }
+      );
+    });
+
+    afterEach(() => {
+      window.location = location;
+    });
+
+    context("with a redirect response", () => {
+      const event = {
+        "detail": {
+          "fetchResponse": {
+            "response": {
+              "redirected": true,
+              "url": "https://example.com"
+            }
+          }
+        }
+      };
+
+      it("redirects", () => {
+        instance.handleRedirect(event);
+
+        expect(window.location.toString()).to.be.eq("https://example.com");
+      });
+    });
+
+    context("with no redirect response", () => {
+      const event = { "detail": { "fetchResponse": { "response": {} } } };
+
+      it("does not redirect", () => {
+        instance.handleRedirect(event);
+
+        expect(window.location.toString()).to.be.eq("about:blank");
+      });
+    });
+  });
+
   context("#messageConnected", () => {
     const event = { "detail": { "height": 3 } };
 

--- a/spec/models/character_spec.rb
+++ b/spec/models/character_spec.rb
@@ -56,4 +56,20 @@ describe Character, type: :model do
 
     it { is_expected.to eq(instance) }
   end
+
+  describe "#inactive?", :freeze_time do
+    subject(:inactive?) { character.inactive? }
+
+    context "when not active within the duration" do
+      let(:character) { create(:character, :inactive) }
+
+      it { is_expected.to eq(true) }
+    end
+
+    context "when active within the duration" do
+      let(:character) { create(:character) }
+
+      it { is_expected.to eq(false) }
+    end
+  end
 end

--- a/spec/views/game/chat/_command.html_spec.rb
+++ b/spec/views/game/chat/_command.html_spec.rb
@@ -16,6 +16,7 @@ describe "game/chat/_command.html.erb", type: :view do
   it "renders the command form" do
     actions = "submit->chat#aliasCommand " \
               "submit->chat#validateCommand " \
+              "turbo:submit-end->chat#handleRedirect " \
               "turbo:submit-end->chat#resetForm"
 
     expect(html).to have_css(


### PR DESCRIPTION
Characters aren't automatically signed out when going inactive yet, but when they are inactive they shouldn't be allowed access to the game. This will redirect the user to the character list if they're inactive when loading the game or sending a command.