### PR TITLE
Assure safety in old migrations to fix strong migrations.

### DIFF
--- a/db/migrate/20210921004918_add_room_to_characters.rb
+++ b/db/migrate/20210921004918_add_room_to_characters.rb
@@ -2,8 +2,10 @@
 
 class AddRoomToCharacters < ActiveRecord::Migration[6.1]
   def change
-    change_table :characters do |t|
-      t.references :room, null: false, index: true
+    safety_assured do
+      change_table :characters do |t|
+        t.references :room, null: false, index: true
+      end
     end
   end
 end

--- a/db/migrate/20210922004027_add_level_to_characters.rb
+++ b/db/migrate/20210922004027_add_level_to_characters.rb
@@ -2,8 +2,10 @@
 
 class AddLevelToCharacters < ActiveRecord::Migration[6.1]
   def change
-    change_table :characters do |t|
-      t.integer :level, null: false, default: 1
+    safety_assured do
+      change_table :characters do |t|
+        t.integer :level, null: false, default: 1
+      end
     end
   end
 end

--- a/db/migrate/20210922004922_add_experience_to_characters.rb
+++ b/db/migrate/20210922004922_add_experience_to_characters.rb
@@ -2,8 +2,10 @@
 
 class AddExperienceToCharacters < ActiveRecord::Migration[6.1]
   def change
-    change_table :characters do |t|
-      t.integer :experience, null: false, default: 0
+    safety_assured do
+      change_table :characters do |t|
+        t.integer :experience, null: false, default: 0
+      end
     end
   end
 end

--- a/db/migrate/20210924230942_add_active_at_to_characters.rb
+++ b/db/migrate/20210924230942_add_active_at_to_characters.rb
@@ -2,11 +2,13 @@
 
 class AddActiveAtToCharacters < ActiveRecord::Migration[6.1]
   def change
-    change_table :characters do |t|
-      t.datetime :active_at, null: false, default: -> { "CURRENT_TIMESTAMP" }, index: true
+    safety_assured do
+      change_table :characters do |t|
+        t.datetime :active_at, null: false, default: -> { "CURRENT_TIMESTAMP" }, index: true
 
-      t.index %i(room_id active_at)
-      t.remove_index :room_id
+        t.index %i(room_id active_at)
+        t.remove_index :room_id
+      end
     end
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -31,7 +31,7 @@ ActiveRecord::Schema.define(version: 2021_09_24_230942) do
     t.bigint "room_id", null: false
     t.integer "level", default: 1, null: false
     t.integer "experience", default: 0, null: false
-    t.datetime "active_at", default: -> { "CURRENT_TIMESTAMP" }, null: false
+    t.datetime "active_at", precision: 6, default: -> { "CURRENT_TIMESTAMP" }, null: false
     t.index ["account_id"], name: "index_characters_on_account_id"
     t.index ["active_at"], name: "index_characters_on_active_at"
     t.index ["name"], name: "index_characters_on_name", unique: true


### PR DESCRIPTION
This was an issue because I removed the `start_after` setting which results in the old migrations throwing errors.