### PR TITLE
Adjust spawn queries to respect the provided sort order.

### DIFF
--- a/app/services/clock/activate_spawns.rb
+++ b/app/services/clock/activate_spawns.rb
@@ -2,13 +2,13 @@
 
 module Clock
   class ActivateSpawns
-    LIMIT = 256
+    LIMIT = 128
 
     # Activates spawns due to be activated.
     #
     # @return [void]
     def self.call
-      spawns_to_activate.find_each do |spawn|
+      spawns_to_activate.each do |spawn|
         activate!(spawn)
       end
     end

--- a/app/services/clock/expire_spawns.rb
+++ b/app/services/clock/expire_spawns.rb
@@ -2,13 +2,13 @@
 
 module Clock
   class ExpireSpawns
-    LIMIT = 256
+    LIMIT = 128
 
     # Expires spawns due to be expried.
     #
     # @return [void]
     def self.call
-      spawns_to_expire.find_each do |spawn|
+      spawns_to_expire.each do |spawn|
         expire!(spawn)
       end
     end


### PR DESCRIPTION
Using `find_each` doesn't respect the timestamp ordering, so I switched the services to use `each`.

And since switching to `each` will load all the objects at once, I lowered the limit that are handled at once. Even at 128 per minute, that's still 7,680 activations or expirations an hour which will be plenty for now. If it's ever an issue in the future there will hopefully be performance monitoring to appropriate adjust the load as needed.