### PR TITLE
Add duration and frequency to spawn seed, and activate immediately.

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,6 +6,16 @@ Room.find_or_initialize_by(x: 0, y: 0, z: 0).tap do |room|
       The street is dusty and unkept. There is a small tavern to the west.
     DESCRIPTION
   )
+
+  Monster.find_or_create_by(name: "Rat").tap do |rat|
+    Spawn.find_or_create_by(base: rat, room: room).tap do |spawn|
+      spawn.update(
+        activates_at: Time.current,
+        duration:     2.minutes,
+        frequency:    1.minute
+      )
+    end
+  end
 end
 
 Room.find_or_initialize_by(x: -1, y: 0, z: 0).tap do |room|
@@ -27,8 +37,4 @@ Room.find_or_initialize_by(x: -1, y: 0, z: -1).tap do |room|
       main room.
     DESCRIPTION
   )
-end
-
-Monster.find_or_create_by(name: "Rat").tap do |rat|
-  Spawn.find_or_create_by(base: rat, entity: rat.dup, room: Room.find_by(x: 0, y: 0, z: 0))
 end


### PR DESCRIPTION
The seed was added before duration and frequency so it would never spawn. This changes it to activate immediately, or at least when the activation clock service runs next, and sets the duration and frequency attributes.