### PR TITLE
Handle missing entity when expiring a spawn.

### DIFF
--- a/app/services/spawns/expire.rb
+++ b/app/services/spawns/expire.rb
@@ -9,7 +9,7 @@ module Spawns
     # @return [void]
     def self.call(spawn)
       spawn.transaction do
-        spawn.entity.destroy!
+        spawn.entity&.destroy!
         spawn.update!(
           activates_at: spawn.frequency ? Time.current + spawn.frequency : nil,
           entity:       nil,

--- a/spec/services/spawns/expire_spec.rb
+++ b/spec/services/spawns/expire_spec.rb
@@ -51,5 +51,13 @@ describe Spawns::Expire, type: :service do
         expect(spawn.reload.activates_at).to be_nil
       end
     end
+
+    context "without an entity" do
+      it "does not raise an error" do
+        spawn = create(:spawn, :monster, entity: nil, expires_at: Time.current)
+
+        expect { described_class.call(spawn) }.not_to raise_error
+      end
+    end
   end
 end


### PR DESCRIPTION
In the rare case where the monster of an expiring spawn is killed while the expiring clock service is running it can raise an error. While it will still update the activation time since the race condition to occur it has to happen in a very small time frame it shouldn't differ by more than a second.