### PR TITLE
Correct whisper feature tests and ensure others correctly test missing messages.

### DIFF
--- a/spec/features/commands/direct_spec.rb
+++ b/spec/features/commands/direct_spec.rb
@@ -40,8 +40,10 @@ describe "Sending the direct command", type: :feature, js: true do
 
     send_command(:direct, nearby_character.name, message)
 
-    using_session(:distant_character) do
-      expect(page).not_to have_css("#messages .message-direct")
+    wait_for(have_direct(message, from: character, to: nearby_character)) do
+      using_session(:distant_character) do
+        expect(page).not_to have_css("#messages .message-direct")
+      end
     end
   end
 

--- a/spec/features/commands/emote_spec.rb
+++ b/spec/features/commands/emote_spec.rb
@@ -35,8 +35,10 @@ describe "Sending the emote command", type: :feature, js: true do
 
     send_command(:emote, message)
 
-    using_session(:distant_character) do
-      expect(page).not_to have_css("#messages .message-emote")
+    wait_for(have_emote(message, from: character)) do
+      using_session(:distant_character) do
+        expect(page).not_to have_css("#messages .message-emote")
+      end
     end
   end
 

--- a/spec/features/commands/look_spec.rb
+++ b/spec/features/commands/look_spec.rb
@@ -23,8 +23,10 @@ describe "Sending the look command", type: :feature, js: true do
 
     send_command(:look)
 
-    using_session(:nearby_character) do
-      expect(page).not_to have_look_message(room, count: 2)
+    wait_for(have_look_message(room, count: 2)) do
+      using_session(:nearby_character) do
+        expect(page).not_to have_look_message(room, count: 2)
+      end
     end
   end
 end

--- a/spec/features/commands/say_spec.rb
+++ b/spec/features/commands/say_spec.rb
@@ -35,8 +35,10 @@ describe "Sending the say command", type: :feature, js: true do
 
     send_command(:say, message)
 
-    using_session(:distant_character) do
-      expect(page).not_to have_css("#messages .message-say")
+    wait_for(have_message(message, from: character)) do
+      using_session(:distant_character) do
+        expect(page).not_to have_css("#messages .message-say")
+      end
     end
   end
 

--- a/spec/features/commands/unknown_spec.rb
+++ b/spec/features/commands/unknown_spec.rb
@@ -23,8 +23,10 @@ describe "Sending an unknown command", type: :feature, js: true do
 
     send_text(command)
 
-    using_session(:nearby_character) do
-      expect(page).not_to have_unknown_command_message(command)
+    wait_for(have_unknown_command_message(command)) do
+      using_session(:nearby_character) do
+        expect(page).not_to have_unknown_command_message(command)
+      end
     end
   end
 

--- a/spec/features/commands/whisper_spec.rb
+++ b/spec/features/commands/whisper_spec.rb
@@ -34,14 +34,16 @@ describe "Sending the whisper command", type: :feature, js: true do
   end
 
   it "does not broadcast the message to the room" do
-    using_session(:nearby_character) do
-      sign_in_as_character nearby_character
+    using_session(:other_character) do
+      sign_in_as_character create(:character, room: character.room)
     end
 
     send_command(:whisper, nearby_character.name, message)
 
-    using_session(:nearby_character) do
-      expect(page).not_to have_css("#messages .message-whisper")
+    wait_for(have_source_whisper(message, from: character, to: nearby_character)) do
+      using_session(:other_character) do
+        expect(page).not_to have_css("#messages .message-whisper")
+      end
     end
   end
 
@@ -52,8 +54,10 @@ describe "Sending the whisper command", type: :feature, js: true do
 
     send_command(:whisper, nearby_character.name, message)
 
-    using_session(:distant_character) do
-      expect(page).not_to have_css("#messages .message-whisper")
+    wait_for(have_source_whisper(message, from: character, to: nearby_character)) do
+      using_session(:distant_character) do
+        expect(page).not_to have_css("#messages .message-whisper")
+      end
     end
   end
 


### PR DESCRIPTION
Corrects a whisper feature test to send to a different character when ensuring it's not broadcast to the room.

Also adds a lot of waiting to feature tests with negative assertions, since if we don't wait for the successful command results we can't be sure the negative assertions are truly passing.