### PR TITLE
Allow monsters to belong to rooms directly.

### DIFF
--- a/app/models/monster.rb
+++ b/app/models/monster.rb
@@ -6,6 +6,8 @@ class Monster < ApplicationRecord
 
   has_one :spawn, foreign_key: :entity_id, inverse_of: :entity, dependent: :nullify
 
+  belongs_to :room, optional: true
+
   validates :name, presence: true,
                    length:   { in: MINIMUM_NAME_LENGTH..MAXIMUM_NAME_LENGTH }
 end

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -3,7 +3,7 @@
 class Room < ApplicationRecord
   has_many :characters, dependent: :restrict_with_exception
   has_many :spawns, dependent: :destroy
-  has_many :monsters, through: :spawns, source: :entity, source_type: "Monster", dependent: :destroy
+  has_many :monsters, dependent: :destroy
 
   validates :description, presence: true
   validates :x, numericality: { only_integer: true },

--- a/app/models/spawn.rb
+++ b/app/models/spawn.rb
@@ -4,4 +4,17 @@ class Spawn < ApplicationRecord
   belongs_to :base, polymorphic: true
   belongs_to :entity, polymorphic: true, optional: true, dependent: :destroy
   belongs_to :room
+
+  validate :base_cannot_belong_to_room, if: :base, on: :create
+
+  private
+
+  # Ensure the base does not belong to a room.
+  #
+  # @return [void]
+  def base_cannot_belong_to_room
+    if base.room.present?
+      errors.add(:base, :room)
+    end
+  end
 end

--- a/app/services/spawns/activate.rb
+++ b/app/services/spawns/activate.rb
@@ -2,7 +2,7 @@
 
 module Spawns
   class Activate
-    # Activates a spawn by creating the entity, clearing the activation time,
+    # Activates a spawn by building the entity, clearing the activation time,
     # and assigning an expiration time if the spawn has a duration.
     #
     # @param [Spawn] spawn The spawn to activate.
@@ -10,9 +10,21 @@ module Spawns
     def self.call(spawn)
       spawn.update!(
         activates_at: nil,
-        entity:       spawn.base.dup,
+        entity:       build_entity(spawn),
         expires_at:   spawn.duration ? Time.current + spawn.duration : nil
       )
     end
+
+    # Duplicate the spawn base entity, assign the spawn room to the entity, and
+    # return the new entity.
+    #
+    # @param [Spawn] spawn The spaw to build an entity for.
+    # @return [Monster] The entity created.
+    def self.build_entity(spawn)
+      entity = spawn.base.dup
+      entity.room_id = spawn.room_id
+      entity
+    end
+    private_class_method :build_entity
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -31,6 +31,12 @@ en:
       account:
         email: "E-mail Address"
         password: "Password"
+    errors:
+      models:
+        spawn:
+          attributes:
+            base:
+              room: "can't belong to a room"
 
   characters:
     enter:

--- a/db/migrate/20220602000944_add_room_to_monsters.rb
+++ b/db/migrate/20220602000944_add_room_to_monsters.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AddRoomToMonsters < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def change
+    add_reference :monsters, :room, index: { algorithm: :concurrently }
+    add_foreign_key :monsters, :rooms, validate: false
+  end
+end

--- a/db/migrate/20220603003641_validate_add_room_to_monsters.rb
+++ b/db/migrate/20220603003641_validate_add_room_to_monsters.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ValidateAddRoomToMonsters < ActiveRecord::Migration[7.0]
+  def change
+    validate_foreign_key :monsters, :rooms
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_03_28_235622) do
+ActiveRecord::Schema[7.0].define(version: 2022_06_03_003641) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -45,6 +45,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_03_28_235622) do
     t.integer "current_health", default: 5, null: false
     t.integer "maximum_health", default: 5, null: false
     t.integer "experience", default: 0, null: false
+    t.bigint "room_id"
+    t.index ["room_id"], name: "index_monsters_on_room_id"
   end
 
   create_table "rooms", force: :cascade do |t|
@@ -77,4 +79,5 @@ ActiveRecord::Schema[7.0].define(version: 2022_03_28_235622) do
   end
 
   add_foreign_key "characters", "accounts"
+  add_foreign_key "monsters", "rooms"
 end

--- a/spec/factories/monster.rb
+++ b/spec/factories/monster.rb
@@ -2,17 +2,9 @@
 
 FactoryBot.define do
   factory :monster do
+    room
+
     name
     experience { 5 }
-
-    transient do
-      room { nil }
-    end
-
-    after(:create) do |monster, evaluator|
-      if evaluator.room.present?
-        create(:spawn, :monster, base: monster.dup, entity: monster, room: evaluator.room)
-      end
-    end
   end
 end

--- a/spec/factories/spawn.rb
+++ b/spec/factories/spawn.rb
@@ -5,8 +5,8 @@ FactoryBot.define do
     room
 
     trait :monster do
-      base { build(:monster) }
-      entity { build(:monster) }
+      base { create(:monster, room: nil) }
+      entity { build(:monster, room: room) }
     end
   end
 end

--- a/spec/features/commands/attack_spec.rb
+++ b/spec/features/commands/attack_spec.rb
@@ -3,10 +3,10 @@
 require "rails_helper"
 
 describe "Sending the attack command", type: :feature, js: true do
-  let(:character) { create(:character, room: spawn.room) }
-  let(:monster)   { create(:monster, room: room) }
-  let(:room)      { create(:room) }
-  let(:spawn)     { monster.spawn }
+  let(:character) { create(:character, room: room) }
+  let(:monster)   { spawn.entity }
+  let(:room)      { spawn.room }
+  let(:spawn)     { create(:spawn, :monster) }
 
   before do
     sign_in_as_character character
@@ -75,7 +75,9 @@ describe "Sending the attack command", type: :feature, js: true do
   end
 
   context "when the monster is killed" do
-    let(:monster) { create(:monster, room: room, current_health: 0) }
+    before do
+      monster.update!(current_health: 1)
+    end
 
     it "displays the attacker killed message to the sender" do
       send_command(:attack, monster.name)

--- a/spec/models/monster_spec.rb
+++ b/spec/models/monster_spec.rb
@@ -5,6 +5,8 @@ require "rails_helper"
 describe Monster, type: :model do
   subject(:monster) { create(:monster) }
 
+  it { is_expected.to belong_to(:room).optional }
+
   it do
     expect(monster).to have_one(:spawn)
       .with_foreign_key(:entity_id)

--- a/spec/models/room_spec.rb
+++ b/spec/models/room_spec.rb
@@ -9,14 +9,7 @@ describe Room, type: :model do
     expect(room).to have_many(:characters).dependent(:restrict_with_exception)
   end
 
-  it do
-    expect(room).to have_many(:monsters)
-      .through(:spawns)
-      .source(:entity)
-      .class_name("Monster")
-      .dependent(:destroy)
-  end
-
+  it { is_expected.to have_many(:monsters).dependent(:destroy) }
   it { is_expected.to have_many(:spawns).dependent(:destroy) }
 
   it { is_expected.to validate_presence_of(:description) }

--- a/spec/models/spawn_spec.rb
+++ b/spec/models/spawn_spec.rb
@@ -6,4 +6,7 @@ describe Spawn, type: :model do
   it { is_expected.to belong_to(:base) }
   it { is_expected.to belong_to(:entity).dependent(:destroy).optional(true) }
   it { is_expected.to belong_to(:room) }
+
+  it { is_expected.to allow_value(build(:monster, room: nil)).for(:base).on(:create) }
+  it { is_expected.not_to allow_value(build(:monster, room: build(:room))).for(:base).on(:create) }
 end

--- a/spec/services/spawns/activate_spec.rb
+++ b/spec/services/spawns/activate_spec.rb
@@ -10,8 +10,16 @@ describe Spawns::Activate, type: :service do
       described_class.call(spawn)
 
       expect(spawn.reload.entity.attributes).to include(
-        spawn.base.attributes.except("id", "created_at", "updated_at")
+        spawn.base.attributes.except("id", "room_id", "created_at", "updated_at")
       )
+    end
+
+    it "assigns the spawn room to the entity" do
+      spawn = create(:spawn, :monster, entity: nil, activates_at: Time.current)
+
+      described_class.call(spawn)
+
+      expect(spawn.reload.entity.room).to eq(spawn.room)
     end
 
     it "clears the activates_at attribute" do

--- a/spec/views/game/_surroundings.html.erb_spec.rb
+++ b/spec/views/game/_surroundings.html.erb_spec.rb
@@ -46,11 +46,14 @@ describe "game/_surroundings.html.erb", type: :view do
   end
 
   context "with monsters" do
-    let(:monster_1) { create(:monster, name: "Blob") }
-    let(:monster_2) { create(:monster, name: "Rat") }
-    let(:room)      { create(:room, spawns: [spawn_1, spawn_2]) }
-    let(:spawn_1)   { create(:spawn, :monster, entity: monster_1) }
-    let(:spawn_2)   { create(:spawn, :monster, entity: monster_2) }
+    let(:monster_1) { create(:monster, room: room, name: "Blob") }
+    let(:monster_2) { create(:monster, room: room, name: "Rat") }
+    let(:room)      { create(:room) }
+
+    before do
+      create(:spawn, :monster, entity: monster_1, room: room)
+      create(:spawn, :monster, entity: monster_2, room: room)
+    end
 
     it "renders the surrounding monsters ordered by name" do
       expect(html).to have_css(


### PR DESCRIPTION
Fixes #127.

Also ensures a spawn base can't belong to a room.