### PR TITLE
Update the gitignore file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,10 +2,6 @@ app/assets/builds/*
 coverage/
 log/
 node_modules/
-public/packs-test/
-public/packs/
 tmp/
 
-!.ruby-version
-!Procfile.dev
 !app/assets/builds/.keep


### PR DESCRIPTION
- The `packs` and `packs-test` directory are no longer created.
- The two inclusions are no longer necessary due to simplifying my global ignore file.