### PR TITLE
Switch to a script for releasing.

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
 clock: bundle exec rails runner ./clock.rb
-release: bundle exec rake db:migrate
+release: bin/release
 web: bundle exec puma -C config/puma.rb

--- a/bin/release
+++ b/bin/release
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+if [ "$RAILS_ENV" != "production" ]; then
+  echo "Attempting release outside of a production environment."
+  exit 1
+fi
+
+if [ "$RELEASE_DATABASE_RESET" == "true" ]; then
+  echo "Resetting the database..."
+  bundle exec rails db:migrate VERSION=0
+fi
+
+echo "Running database migrations..."
+bundle exec rails db:migrate
+
+if [ "$RELEASE_DATABASE_RESET" == "true" ]; then
+  echo "Seeding the database..."
+  bundle exec rails db:seed
+fi


### PR DESCRIPTION
Adds support for resetting the database when releasing, which is useful to avoid issues when pushing different branches to staging.