### PR TITLE
Add option to remove yarn install from the JavaScript build task.

### DIFF
--- a/lib/tasks/javascript.rake
+++ b/lib/tasks/javascript.rake
@@ -14,4 +14,16 @@ namespace :javascript do
       system "yarn test"
     end
   end
+
+  if ENV["REMOVE_JS_BUILD_YARN_INSTALL"] == "true"
+    Rake::Task["javascript:build"].clear
+
+    desc "Build your JavaScript bundle"
+    task :build do # rubocop:disable Rails/RakeEnvironment
+      unless system("yarn build")
+        raise "jsbundling-rails: Command build failed, " \
+              "ensure yarn is installed and `yarn build` runs without errors"
+      end
+    end
+  end
 end


### PR DESCRIPTION
When deploying with a Node.js buildpack, the dependencies will already be installed making this call redundant. The ability to remove it will speed up deployments.