### PR TITLE
Remove the spawn duration for the Rat in database seeds.

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -13,7 +13,7 @@ Room.find_or_initialize_by(x: 0, y: 0, z: 0).tap do |room|
     Spawn.find_or_create_by(base: rat, room: room).tap do |spawn|
       spawn.update(
         activates_at: Time.current,
-        duration:     2.minutes,
+        duration:     nil,
         frequency:    1.minute
       )
     end


### PR DESCRIPTION
This prevents the spawn from expiring until it's decided how to handle expired spawns with characters in the same room.