### PR TITLE
Add missing validations to characters, monsters, and spawns.

### DIFF
--- a/app/models/character.rb
+++ b/app/models/character.rb
@@ -10,12 +10,12 @@ class Character < ApplicationRecord
   belongs_to :room
 
   validates :current_health, presence:     true,
-                             numericality: { only_integer: true }
-  validates :experience, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
+                             numericality: { greater_than: 0, only_integer: true }
+  validates :experience, numericality: { greater_than_or_equal_to: 0, only_integer: true }
   validates :level, presence:     true,
-                    numericality: { only_integer: true, greater_than_or_equal_to: 1 }
+                    numericality: { greater_than_or_equal_to: 1, only_integer: true }
   validates :maximum_health, presence:     true,
-                             numericality: { only_integer: true }
+                             numericality: { greater_than: 0, only_integer: true }
   validates :name, presence:   true,
                    length:     { in: MINIMUM_NAME_LENGTH..MAXIMUM_NAME_LENGTH },
                    uniqueness: { case_sensitive: false }

--- a/app/models/monster.rb
+++ b/app/models/monster.rb
@@ -9,9 +9,11 @@ class Monster < ApplicationRecord
   belongs_to :room, optional: true
 
   validates :current_health, presence:     true,
-                             numericality: { only_integer: true }
+                             numericality: { greater_than: 0, only_integer: true }
+  validates :experience, presence:     true,
+                         numericality: { greater_than: 0, only_integer: true }
   validates :maximum_health, presence:     true,
-                             numericality: { only_integer: true }
+                             numericality: { greater_than: 0, only_integer: true }
   validates :name, presence: true,
                    length:   { in: MINIMUM_NAME_LENGTH..MAXIMUM_NAME_LENGTH }
 end

--- a/app/models/spawn.rb
+++ b/app/models/spawn.rb
@@ -7,6 +7,9 @@ class Spawn < ApplicationRecord
 
   validate :base_cannot_belong_to_room, if: :base, on: :create
 
+  validates :duration, numericality: { allow_nil: true, greater_than: 0, only_integer: true }
+  validates :frequency, numericality: { allow_nil: true, greater_than: 0, only_integer: true }
+
   private
 
   # Ensure the base does not belong to a room.

--- a/app/services/commands/attack_command.rb
+++ b/app/services/commands/attack_command.rb
@@ -96,9 +96,10 @@ module Commands
     # @return [void]
     def damage_target
       target.current_health -= damage
-      target.save!
 
       if target.current_health.positive?
+        target.save!
+
         broadcast_attack
       else
         broadcast_killed

--- a/spec/models/character_spec.rb
+++ b/spec/models/character_spec.rb
@@ -12,23 +12,23 @@ describe Character, type: :model do
     subject(:character) { build(:character) }
 
     it { is_expected.to validate_presence_of(:current_health) }
-    it { is_expected.to validate_numericality_of(:current_health).only_integer }
+    it { is_expected.to validate_numericality_of(:current_health).is_greater_than(0).only_integer }
 
     it { is_expected.to validate_presence_of(:maximum_health) }
-    it { is_expected.to validate_numericality_of(:maximum_health).only_integer }
+    it { is_expected.to validate_numericality_of(:maximum_health).is_greater_than(0).only_integer }
 
     it { is_expected.to validate_presence_of(:level) }
 
     it { is_expected.to validate_presence_of(:name) }
     it { is_expected.to validate_uniqueness_of(:name).case_insensitive }
 
-    it "disallows :experience from being a decimal number not greater than or equal to 0" do
+    it "validates that :experience looks like an integer greater than or equal to 0" do
       expect(character).to validate_numericality_of(:experience)
         .is_greater_than_or_equal_to(0)
         .only_integer
     end
 
-    it "disallows :level from being a decimal number not greater than or equal to 1" do
+    it "validates that :level looks like an integer greater than or equal to 1" do
       expect(character).to validate_numericality_of(:level)
         .is_greater_than_or_equal_to(1)
         .only_integer

--- a/spec/models/monster_spec.rb
+++ b/spec/models/monster_spec.rb
@@ -17,10 +17,13 @@ describe Monster, type: :model do
     subject(:monster) { build(:monster) }
 
     it { is_expected.to validate_presence_of(:current_health) }
-    it { is_expected.to validate_numericality_of(:current_health).only_integer }
+    it { is_expected.to validate_numericality_of(:current_health).is_greater_than(0).only_integer }
+
+    it { is_expected.to validate_presence_of(:experience) }
+    it { is_expected.to validate_numericality_of(:experience).is_greater_than(0).only_integer }
 
     it { is_expected.to validate_presence_of(:maximum_health) }
-    it { is_expected.to validate_numericality_of(:maximum_health).only_integer }
+    it { is_expected.to validate_numericality_of(:maximum_health).is_greater_than(0).only_integer }
 
     it { is_expected.to validate_presence_of(:name) }
 

--- a/spec/models/spawn_spec.rb
+++ b/spec/models/spawn_spec.rb
@@ -10,7 +10,23 @@ describe Spawn, type: :model do
   end
 
   describe "validations" do
+    subject(:spawn) { build(:spawn) }
+
     it { is_expected.to allow_value(build(:monster, room: nil)).for(:base).on(:create) }
     it { is_expected.not_to allow_value(build(:monster, room: build(:room))).for(:base).on(:create) }
+
+    it "validates that :duration looks like an integer greater than zero, allowing nil" do
+      expect(spawn).to validate_numericality_of(:duration)
+        .is_greater_than(0)
+        .only_integer
+        .allow_nil
+    end
+
+    it "validates that :frequency looks like an integer greater than zero, allowing nil" do
+      expect(spawn).to validate_numericality_of(:frequency)
+        .is_greater_than(0)
+        .only_integer
+        .allow_nil
+    end
   end
 end


### PR DESCRIPTION
This also results in a target not being saved when attacked and killed to avoid saving it with a current health of zero.