### PR TITLE
Exclude support files from test backtraces.

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -46,6 +46,7 @@ RSpec.configure do |config|
 
   # Filter libraries in backtraces.
   config.backtrace_exclusion_patterns << %r{/gems/}
+  config.backtrace_exclusion_patterns << %r{spec/support}
 
   # Patch for rspec/rails issue #2485.
   config.before(:context, type: :view) do


### PR DESCRIPTION
I noticed the prosopite file appearing in the backtrace and figured it'd best to ignore them all.