### PR TITLE
Ensure character and monster current health doesn't exceed maximum.

### DIFF
--- a/app/models/character.rb
+++ b/app/models/character.rb
@@ -9,13 +9,13 @@ class Character < ApplicationRecord
   belongs_to :account
   belongs_to :room
 
-  validates :current_health, presence:     true,
-                             numericality: { greater_than: 0, only_integer: true }
+  validates :current_health, numericality: {
+    less_than_or_equal_to: :maximum_health, greater_than: 0, only_integer: true
+  }
   validates :experience, numericality: { greater_than_or_equal_to: 0, only_integer: true }
   validates :level, presence:     true,
                     numericality: { greater_than_or_equal_to: 1, only_integer: true }
-  validates :maximum_health, presence:     true,
-                             numericality: { greater_than: 0, only_integer: true }
+  validates :maximum_health, numericality: { greater_than: 0, only_integer: true }
   validates :name, presence:   true,
                    length:     { in: MINIMUM_NAME_LENGTH..MAXIMUM_NAME_LENGTH },
                    uniqueness: { case_sensitive: false }

--- a/app/models/monster.rb
+++ b/app/models/monster.rb
@@ -10,12 +10,12 @@ class Monster < ApplicationRecord
 
   belongs_to :room, optional: true
 
-  validates :current_health, presence:     true,
-                             numericality: { greater_than: 0, only_integer: true }
+  validates :current_health, numericality: {
+    less_than_or_equal_to: :maximum_health, greater_than: 0, only_integer: true
+  }
   validates :experience, presence:     true,
                          numericality: { greater_than: 0, only_integer: true }
-  validates :maximum_health, presence:     true,
-                             numericality: { greater_than: 0, only_integer: true }
+  validates :maximum_health, numericality: { greater_than: 0, only_integer: true }
   validates :name, presence: true,
                    length:   { in: MINIMUM_NAME_LENGTH..MAXIMUM_NAME_LENGTH }
 end

--- a/db/migrate/20221205042633_add_current_health_constraints.rb
+++ b/db/migrate/20221205042633_add_current_health_constraints.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class AddCurrentHealthConstraints < ActiveRecord::Migration[7.0]
+  def change
+    add_check_constraint :characters,
+                         "current_health <= maximum_health",
+                         name:     "characters_current_health_check",
+                         validate: false
+    add_check_constraint :monsters,
+                         "current_health <= maximum_health",
+                         name:     "monsters_current_health_check",
+                         validate: false
+  end
+end

--- a/db/migrate/20221205042735_validate_add_current_health_constraints.rb
+++ b/db/migrate/20221205042735_validate_add_current_health_constraints.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class ValidateAddCurrentHealthConstraints < ActiveRecord::Migration[7.0]
+  def change
+    validate_check_constraint :characters, name: "characters_current_health_check"
+    validate_check_constraint :monsters, name: "monsters_current_health_check"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_10_15_150719) do
+ActiveRecord::Schema[7.0].define(version: 2022_12_05_042735) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -38,6 +38,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_15_150719) do
     t.index ["active_at", "playing"], name: "index_characters_on_active_at_and_playing"
     t.index ["name"], name: "index_characters_on_name", unique: true
     t.index ["room_id", "active_at"], name: "index_characters_on_room_id_and_active_at"
+    t.check_constraint "current_health <= maximum_health", name: "characters_current_health_check"
   end
 
   create_table "monsters", force: :cascade do |t|
@@ -51,6 +52,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_15_150719) do
     t.string "event_handlers", default: [], null: false, array: true
     t.index ["event_handlers"], name: "index_monsters_on_event_handlers"
     t.index ["room_id"], name: "index_monsters_on_room_id"
+    t.check_constraint "current_health <= maximum_health", name: "monsters_current_health_check"
   end
 
   create_table "rooms", force: :cascade do |t|

--- a/spec/models/character_spec.rb
+++ b/spec/models/character_spec.rb
@@ -11,16 +11,19 @@ describe Character do
   describe "validations" do
     subject(:character) { build(:character) }
 
-    it { is_expected.to validate_presence_of(:current_health) }
     it { is_expected.to validate_numericality_of(:current_health).is_greater_than(0).only_integer }
 
-    it { is_expected.to validate_presence_of(:maximum_health) }
     it { is_expected.to validate_numericality_of(:maximum_health).is_greater_than(0).only_integer }
 
     it { is_expected.to validate_presence_of(:level) }
 
     it { is_expected.to validate_presence_of(:name) }
     it { is_expected.to validate_uniqueness_of(:name).case_insensitive }
+
+    it "validates that :current_health is less than or equal to :maximum_health" do
+      expect(character).to validate_numericality_of(:current_health)
+        .is_less_than_or_equal_to(character.maximum_health)
+    end
 
     it "validates that :experience looks like an integer greater than or equal to 0" do
       expect(character).to validate_numericality_of(:experience)

--- a/spec/models/monster_spec.rb
+++ b/spec/models/monster_spec.rb
@@ -22,16 +22,19 @@ describe Monster do
   describe "validations" do
     subject(:monster) { build(:monster) }
 
-    it { is_expected.to validate_presence_of(:current_health) }
     it { is_expected.to validate_numericality_of(:current_health).is_greater_than(0).only_integer }
 
     it { is_expected.to validate_presence_of(:experience) }
     it { is_expected.to validate_numericality_of(:experience).is_greater_than(0).only_integer }
 
-    it { is_expected.to validate_presence_of(:maximum_health) }
     it { is_expected.to validate_numericality_of(:maximum_health).is_greater_than(0).only_integer }
 
     it { is_expected.to validate_presence_of(:name) }
+
+    it "validates that :current_health is less than or equal to :maximum_health" do
+      expect(monster).to validate_numericality_of(:current_health)
+        .is_less_than_or_equal_to(monster.maximum_health)
+    end
 
     it "is expected to validate that the length of :name is between the minimum and maximum" do
       expect(monster).to validate_length_of(:name)


### PR DESCRIPTION
Fixes #193.

This also removes the redundant presence validations.