### PR TITLE
Adjust database pool to account for clock process.

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -1,7 +1,7 @@
 default: &default
   adapter: postgresql
   encoding: unicode
-  pool: <%= ENV.fetch("DATABASE_POOL", ENV.fetch("RAILS_MAX_THREADS") { 5 }) %>
+  pool: <%= ENV.fetch("DATABASE_POOL", ENV.fetch("RAILS_MAX_THREADS") { 5 } + 1) %>
   variables:
     statement_timeout: 5_000
 


### PR DESCRIPTION
I was running into issues with deserialization of jobs locally due to a full connection pool.