### PR TITLE
Add backdoor middleware sign in for speeding up tests.

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "./lib/middleware/backdoor"
+
 Rails.application.configure do
   # Disable caching for classes.
   config.cache_classes = false
@@ -40,4 +42,7 @@ Rails.application.configure do
 
   # Annotate rendered view with file names.
   # config.action_view.annotate_rendered_view_with_filenames = true
+
+  # Add the authentication backdoor middleware.
+  config.middleware.use(Middleware::Backdoor)
 end

--- a/lib/middleware/backdoor.rb
+++ b/lib/middleware/backdoor.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Middleware
+  class Backdoor
+    # Initial the middleware.
+    #
+    # @param [Class] app The Rack application.
+    # @return [void]
+    def initialize(app)
+      @app = app
+    end
+
+    # Update the session with account and character IDs and remove them from
+    # the parameters, when present.
+    #
+    # @param [Hash] env The request environment.
+    # @return [void]
+    def call(env)
+      request = Rack::Request.new(env)
+      request.session.update({
+        account_id:   request.params.delete("account")&.to_i,
+        character_id: request.params.delete("character")&.to_i
+      }.compact)
+
+      env["QUERY_STRING"] = request.params.presence
+
+      @app.call(env)
+    end
+  end
+end

--- a/spec/features/characters/select_spec.rb
+++ b/spec/features/characters/select_spec.rb
@@ -7,6 +7,7 @@ describe "Selecting a character", js: true do
 
   before do
     sign_in_as character.account
+    visit characters_path
   end
 
   it "successfully" do

--- a/spec/features/sessions/destroy_spec.rb
+++ b/spec/features/sessions/destroy_spec.rb
@@ -5,6 +5,7 @@ require "rails_helper"
 describe "Destroying a session" do
   before do
     sign_in
+    visit characters_path
   end
 
   it "successfully" do

--- a/spec/lib/middleware/backdoor_spec.rb
+++ b/spec/lib/middleware/backdoor_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe Middleware::Backdoor do
+  subject(:call) { described_class.new(app).call(env) }
+
+  let(:app) { ->(_) { [200, {}, "OK"] } }
+
+  context "with account and character parameters" do
+    let(:env) do
+      Rack::MockRequest.env_for("", params: { account: 1, character: 2, other: 3 })
+    end
+
+    it "updates the session to include the parameter values" do
+      call
+
+      expect(env["rack.session"]).to eq(account_id: 1, character_id: 2)
+    end
+
+    it "removes the parameters from the query string" do
+      call
+
+      expect(env["QUERY_STRING"]).to eq("other" => "3")
+    end
+  end
+
+  context "without account and character parameters" do
+    let(:env) { Rack::MockRequest.env_for("", params: { test: 4 }) }
+
+    it "does not update the session" do
+      call
+
+      expect(env["rack.session"]).to be_empty
+    end
+
+    it "does not change the query string" do
+      call
+
+      expect(env["QUERY_STRING"]).to eq("test" => "4")
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -2,13 +2,13 @@
 
 ENV["RAILS_ENV"] ||= "test"
 
+require "spec_helper"
 require File.expand_path("../config/environment", __dir__)
 
 if Rails.env.production?
   abort "The Rails environment is running in production mode!"
 end
 
-require "spec_helper"
 require "rails-controller-testing"
 require "rspec/rails"
 

--- a/spec/support/helpers/session.rb
+++ b/spec/support/helpers/session.rb
@@ -24,18 +24,11 @@ module RSpec
         end
 
         def sign_in_as(account)
-          visit root_path
-          click_link t("pages.index.sign_in")
-          fill_in t("activemodel.attributes.account_form.email"),
-                  with: account.email
-          fill_in t("activemodel.attributes.account_form.password"),
-                  with: account.password
-          click_button t("sessions.new.submit")
+          visit root_path(account: account.id)
         end
 
         def sign_in_as_character(character = create(:character))
-          sign_in_as character.account
-          click_button character.name
+          visit root_path(account: character.account_id, character: character.id)
 
           expect(page).to have_css("#sidebar h1", text: character.name)
         end


### PR DESCRIPTION
This speeds up the full test suite by ~60 seconds locally (without coverage) and one of the slower feature tests (the whisper command) by ~3.5 seconds.