### PR TITLE
Avoid loading accounts to check for an active character.

### DIFF
--- a/app/controllers/commands_controller.rb
+++ b/app/controllers/commands_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class CommandsController < ApplicationController
-  before_action :authenticate, :require_active_character
+  before_action :require_active_character
   after_action :mark_character_as_active
 
   rescue_from ActionController::ParameterMissing do

--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -94,7 +94,11 @@ module Authentication
   # @return [void]
   def require_active_character
     if current_character.nil?
-      redirect_to new_character_url
+      if current_account.nil?
+        access_denied
+      else
+        redirect_to new_character_url
+      end
     elsif current_character.inactive?
       redirect_to characters_url
     end

--- a/spec/controllers/concerns/authentication_spec.rb
+++ b/spec/controllers/concerns/authentication_spec.rb
@@ -448,11 +448,13 @@ describe Authentication do
       end
     end
 
-    context "with no character present" do
+    context "with an account present and no character present" do
+      let(:account)           { build_stubbed(:account) }
       let(:new_character_url) { double }
 
       before do
         allow(instance).to receive(:redirect_to)
+        allow(instance).to receive(:current_account).and_return(account)
         allow(instance).to receive(:current_character).and_return(nil)
         allow(instance).to receive(:new_character_url).and_return(new_character_url)
       end
@@ -461,6 +463,23 @@ describe Authentication do
         instance.require_active_character
 
         expect(instance).to have_received(:redirect_to).with(new_character_url)
+      end
+    end
+
+    context "with no account or character present" do
+      let(:account)          { build_stubbed(:account) }
+      let(:new_sessions_url) { double }
+
+      before do
+        allow(instance).to receive(:access_denied)
+        allow(instance).to receive(:current_account).and_return(nil)
+        allow(instance).to receive(:current_character).and_return(nil)
+      end
+
+      it "redirects to new_character_url" do
+        instance.require_active_character
+
+        expect(instance).to have_received(:access_denied)
       end
     end
   end


### PR DESCRIPTION
The account is not currently used in either controller that uses `require_active_character` and removing the query in the commands controller is a decent performance improvement.