### PR TITLE
Avoid existence check when listing characters.

### DIFF
--- a/app/views/characters/index.html.erb
+++ b/app/views/characters/index.html.erb
@@ -10,7 +10,7 @@
       </p>
     <% end %>
 
-    <% if @characters.any? %>
+    <% if @characters.present? %>
       <ul id="characters" class="m-auto w-3/4">
         <% @characters.each do |character| %>
           <li>


### PR DESCRIPTION
It's fine to load the characters here since we're going to use them if they are present instead of performing an additional query to determine if there are any characters to list.