### PR TITLE
Avoid loading character's room to only generate a GlobalID.

### DIFF
--- a/app/models/character.rb
+++ b/app/models/character.rb
@@ -68,4 +68,17 @@ class Character < ApplicationRecord
   def recent?
     Rails.cache.exist?(SELECTED_KEY % id)
   end
+
+  # Return a GlobalID parameter for the character's room.
+  #
+  # @return [String]
+  def room_gid
+    GlobalID.new(
+      URI::GID.build(
+        app:        GlobalID.app,
+        model_name: "Room",
+        model_id:   room_id
+      )
+    ).to_param
+  end
 end

--- a/app/services/commands/attack_command.rb
+++ b/app/services/commands/attack_command.rb
@@ -71,7 +71,7 @@ module Commands
     # @return [void]
     def broadcast_attack
       Turbo::StreamsChannel.broadcast_append_later_to(
-        character.room,
+        character.room_gid,
         target:  "messages",
         partial: "commands/attack/attack/hit",
         locals:  {
@@ -87,7 +87,7 @@ module Commands
     # @return [void]
     def broadcast_killed
       Turbo::StreamsChannel.broadcast_render_later_to(
-        character.room,
+        character.room_gid,
         partial: "commands/attack/attack/killed",
         locals:  {
           attacker_name: character.name,
@@ -103,7 +103,7 @@ module Commands
     # @return [void]
     def broadcast_missed
       Turbo::StreamsChannel.broadcast_append_later_to(
-        character.room,
+        character.room_gid,
         target:  "messages",
         partial: "commands/attack/attack/missed",
         locals:  {

--- a/app/services/commands/direct_command.rb
+++ b/app/services/commands/direct_command.rb
@@ -5,7 +5,7 @@ module Commands
     # Broadcast a direct command to chat.
     def call
       if valid?
-        broadcast_append_later_to(character.room, target: "messages")
+        broadcast_append_later_to(character.room_gid, target: "messages")
       end
     end
 

--- a/app/services/commands/emote_command.rb
+++ b/app/services/commands/emote_command.rb
@@ -9,7 +9,7 @@ module Commands
     # Broadcast an emote command to chat.
     def call
       if valid?
-        broadcast_append_later_to(character.room, target: "messages")
+        broadcast_append_later_to(character.room_gid, target: "messages")
       end
     end
 

--- a/app/services/commands/say_command.rb
+++ b/app/services/commands/say_command.rb
@@ -5,7 +5,7 @@ module Commands
     # Broadcast a say command to chat.
     def call
       if valid?
-        broadcast_append_later_to(character.room, target: "messages")
+        broadcast_append_later_to(character.room_gid, target: "messages")
       end
     end
 

--- a/spec/models/character_spec.rb
+++ b/spec/models/character_spec.rb
@@ -142,4 +142,23 @@ describe Character do
       it { is_expected.to be(false) }
     end
   end
+
+  describe "#room_gid" do
+    subject { character.room_gid }
+
+    let(:character) { build_stubbed(:character) }
+    let(:global_id) { instance_double(GlobalID) }
+    let(:parameter) { double }
+    let(:uri)       { instance_double(URI::GID) }
+
+    before do
+      allow(global_id).to receive(:to_param).and_return(parameter)
+      allow(GlobalID).to receive(:new).with(uri).and_return(global_id)
+      allow(URI::GID).to receive(:build)
+        .with(app: GlobalID.app, model_name: "Room", model_id: character.room_id)
+        .and_return(uri)
+    end
+
+    it { is_expected.to eq(parameter) }
+  end
 end

--- a/spec/services/commands/attack_command_spec.rb
+++ b/spec/services/commands/attack_command_spec.rb
@@ -37,7 +37,7 @@ describe Commands::AttackCommand, type: :service do
 
         expect(Turbo::StreamsChannel).to have_received(:broadcast_append_later_to)
           .with(
-            character.room,
+            character.room_gid,
             target:  "messages",
             partial: "commands/attack/attack/hit",
             locals:  {
@@ -71,7 +71,7 @@ describe Commands::AttackCommand, type: :service do
 
         expect(Turbo::StreamsChannel).to have_received(:broadcast_append_later_to)
           .with(
-            character.room,
+            character.room_gid,
             target:  "messages",
             partial: "commands/attack/attack/missed",
             locals:  {
@@ -108,7 +108,7 @@ describe Commands::AttackCommand, type: :service do
 
         expect(Turbo::StreamsChannel).to have_received(:broadcast_render_later_to)
           .with(
-            character.room,
+            character.room_gid,
             partial: "commands/attack/attack/killed",
             locals:  {
               attacker_name: character.name,

--- a/spec/services/commands/direct_command_spec.rb
+++ b/spec/services/commands/direct_command_spec.rb
@@ -22,7 +22,7 @@ describe Commands::DirectCommand, type: :service do
 
         expect(Turbo::StreamsChannel).to have_received(:broadcast_append_later_to)
           .with(
-            character.room,
+            character.room_gid,
             target:  "messages",
             partial: "commands/direct",
             locals:  {

--- a/spec/services/commands/emote_command_spec.rb
+++ b/spec/services/commands/emote_command_spec.rb
@@ -22,7 +22,7 @@ describe Commands::EmoteCommand, type: :service do
 
         expect(Turbo::StreamsChannel).to have_received(:broadcast_append_later_to)
           .with(
-            character.room,
+            character.room_gid,
             target:  "messages",
             partial: "commands/emote",
             locals:  {
@@ -41,7 +41,7 @@ describe Commands::EmoteCommand, type: :service do
 
           expect(Turbo::StreamsChannel).to have_received(:broadcast_append_later_to)
             .with(
-              character.room,
+              character.room_gid,
               target:  "messages",
               partial: "commands/emote",
               locals:  {

--- a/spec/services/commands/say_command_spec.rb
+++ b/spec/services/commands/say_command_spec.rb
@@ -22,7 +22,7 @@ describe Commands::SayCommand, type: :service do
 
         expect(Turbo::StreamsChannel).to have_received(:broadcast_append_later_to)
           .with(
-            character.room,
+            character.room_gid,
             target:  "messages",
             partial: "commands/say",
             locals:  {


### PR DESCRIPTION
Realized there's no need to query and load the entire room for most commands since it's only being used to generate the GlobalID for where to broadcast a message to.

Debated automatically adding `#{association}_gid` for every `belongs_to` association but it's only used for `Character#room` at the moment so decided not to.