### PR TITLE
Avoid querying for a blank target when attacking.

### DIFF
--- a/app/services/commands/attack_command.rb
+++ b/app/services/commands/attack_command.rb
@@ -179,7 +179,9 @@ module Commands
     # @return [Monster] If a monster is found.
     # @return [nil] If a monster is not found.
     def target
-      @target ||= character.room.monsters.where("LOWER(NAME) = ?", target_name.downcase).first
+      if target_name.present?
+        @target ||= character.room.monsters.where("LOWER(NAME) = ?", target_name.downcase).first
+      end
     end
 
     # Determine if the target is dead or not.

--- a/spec/services/commands/attack_command_spec.rb
+++ b/spec/services/commands/attack_command_spec.rb
@@ -207,6 +207,14 @@ describe Commands::AttackCommand, type: :service do
 
         expect(Turbo::StreamsChannel).not_to have_received(:broadcast_append_later_to)
       end
+
+      it "does not query for the target" do
+        allow(character.room).to receive(:monsters).and_return(Monster.all)
+
+        call
+
+        expect(character.room).not_to have_received(:monsters)
+      end
     end
   end
 


### PR DESCRIPTION
The `target` method is still called for the locals even if the command is considered invalid, leading to a useless query.