### PR TITLE
Improve command throttle handling.

### DIFF
--- a/app/services/command.rb
+++ b/app/services/command.rb
@@ -15,15 +15,6 @@ class Command
     instance.tap(&:call)
   end
 
-  # Determine the throttle limit for the provided command.
-  #
-  # @param [String] input The raw command input.
-  # @return [Integer] The throttle limit for the parsed command.
-  def self.limit(input)
-    command = parse(input)
-    command.const_get(:THROTTLE_LIMIT)
-  end
-
   # Convert a command to a command class.
   #
   # @param [String] input The raw command input.
@@ -34,14 +25,5 @@ class Command
     "commands/#{name}_command".camelize.constantize
   rescue NameError
     Commands::UnknownCommand
-  end
-
-  # Determine the throttle period for the provided command.
-  #
-  # @param [String] input The raw command input.
-  # @return [Integer] The throttle period for the parsed command.
-  def self.period(input)
-    command = parse(input)
-    command.const_get(:THROTTLE_PERIOD)
   end
 end

--- a/app/services/commands/base.rb
+++ b/app/services/commands/base.rb
@@ -15,6 +15,20 @@ module Commands
       @input     = input
     end
 
+    # Determine the throttle limit for the command.
+    #
+    # @return [Integer] The throttle limit for the command.
+    def self.limit
+      const_get(:THROTTLE_LIMIT)
+    end
+
+    # Determine the throttle period for the command.
+    #
+    # @return [Integer] The throttle period for the command.
+    def self.period
+      const_get(:THROTTLE_PERIOD)
+    end
+
     # Execute the command.
     #
     # @abstract Subclass and override to implement command logic.

--- a/config/initializers/throttling.rb
+++ b/config/initializers/throttling.rb
@@ -11,15 +11,16 @@ end
 # defined based on the command.
 Rack::Attack.throttle(
   "accounts/command",
-  limit:  proc { |request| Command.limit(request.params["input"]) },
-  period: proc { |request| Command.period(request.params["input"]) }
+  limit:  proc { |request| request.env["miroha.command"].limit },
+  period: proc { |request| request.env["miroha.command"].period }
 ) do |request|
   if request.post? && request.path == "/commands"
-    account_id = request.session["account_id"]
-    command    = Command.parse(request.params["input"])
-    name       = command.name.demodulize.delete_suffix(Commands::Base::SUFFIX)
+    command = request.env["miroha.command"] = Command.parse(request.params["input"])
 
-    [account_id, name].join("/")
+    [
+      request.session["account_id"],
+      command.name.demodulize.delete_suffix(Commands::Base::SUFFIX)
+    ].join("/")
   end
 end
 

--- a/spec/services/command_spec.rb
+++ b/spec/services/command_spec.rb
@@ -39,30 +39,6 @@ describe Command, type: :service do
     end
   end
 
-  describe ".limit" do
-    subject { described_class.limit("/attack Rat") }
-
-    let(:command) { Commands::AttackCommand }
-
-    before do
-      allow(described_class).to receive(:parse).and_return(command)
-    end
-
-    it { is_expected.to eq(command::THROTTLE_LIMIT) }
-  end
-
-  describe ".period" do
-    subject { described_class.period("/attack Rat") }
-
-    let(:command) { Commands::AttackCommand }
-
-    before do
-      allow(described_class).to receive(:parse).and_return(command)
-    end
-
-    it { is_expected.to eq(command::THROTTLE_PERIOD) }
-  end
-
   describe ".parse" do
     subject { described_class.parse(input) }
 

--- a/spec/services/commands/base_spec.rb
+++ b/spec/services/commands/base_spec.rb
@@ -16,6 +16,30 @@ describe Commands::Base, type: :service do
     end
   end
 
+  describe ".limit" do
+    subject { described_class.limit }
+
+    let(:value) { rand }
+
+    before do
+      allow(described_class).to receive(:const_get).with(:THROTTLE_LIMIT).and_return(value)
+    end
+
+    it { is_expected.to eq(value) }
+  end
+
+  describe ".period" do
+    subject { described_class.period }
+
+    let(:value) { rand }
+
+    before do
+      allow(described_class).to receive(:const_get).with(:THROTTLE_PERIOD).and_return(value)
+    end
+
+    it { is_expected.to eq(value) }
+  end
+
   describe "#call" do
     subject(:call) { instance.call }
 


### PR DESCRIPTION
Avoid parsing the command input multiple times for throttling and move the throttle methods to the base command class.