### PR TITLE
Remove the command class suffix.

### DIFF
--- a/app/services/command.rb
+++ b/app/services/command.rb
@@ -22,8 +22,8 @@ class Command
   def self.parse(input)
     name = input.match(MATCHER)&.captures&.first || DEFAULT_NAME
 
-    "commands/#{name}_command".camelize.constantize
+    "commands/#{name}".camelize.constantize
   rescue NameError
-    Commands::UnknownCommand
+    Commands::Unknown
   end
 end

--- a/app/services/commands/alias.rb
+++ b/app/services/commands/alias.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Commands
-  class AliasCommand < Base
+  class Alias < Base
     # Determine if the command is rendered immediately.
     #
     # @return [Boolean]

--- a/app/services/commands/attack.rb
+++ b/app/services/commands/attack.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Commands
-  class AttackCommand < Base
+  class Attack < Base
     THROTTLE_LIMIT  = 1
     THROTTLE_PERIOD = 1
 

--- a/app/services/commands/base.rb
+++ b/app/services/commands/base.rb
@@ -2,7 +2,6 @@
 
 module Commands
   class Base
-    SUFFIX          = "Command"
     THROTTLE_LIMIT  = 10
     THROTTLE_PERIOD = 5
 
@@ -87,12 +86,12 @@ module Commands
 
     # Return the name of the command.
     #
-    #     Commands::SayCommand
+    #     Commands::Say
     #     # => "say"
     #
     # @return [String]
     def name
-      @name ||= self.class.name.demodulize.delete_suffix(SUFFIX).downcase
+      @name ||= self.class.name.demodulize.downcase
     end
   end
 end

--- a/app/services/commands/direct.rb
+++ b/app/services/commands/direct.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 module Commands
-  class WhisperCommand < Base
-    # Broadcast a whisper command to the target.
+  class Direct < Base
+    # Broadcast a direct command to chat.
     def call
       if valid?
-        broadcast_append_later_to(target, target: "messages")
+        broadcast_append_later_to(character.room_gid, target: "messages")
       end
     end
 
@@ -13,7 +13,7 @@ module Commands
     #
     # @return [Boolean]
     def rendered?
-      true
+      !valid? && message.present?
     end
 
     private
@@ -30,7 +30,7 @@ module Commands
       }
     end
 
-    # Return the message being whispered to the target.
+    # Return the message being directed to the target.
     #
     # @return [String]
     def message

--- a/app/services/commands/emote.rb
+++ b/app/services/commands/emote.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Commands
-  class EmoteCommand < Base
+  class Emote < Base
     DEFAULT_PUNCTUATION    = "."
     PUNCTUATION_CHARACTERS = %w(. ? ! " …).freeze
     PUNCTUATION_MATCHER    = /[#{PUNCTUATION_CHARACTERS.join}]\z/

--- a/app/services/commands/help.rb
+++ b/app/services/commands/help.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Commands
-  class HelpCommand < Base
+  class Help < Base
     # Return help data for each command.
     #
     # @return [Array] An array of command help hashes.

--- a/app/services/commands/look.rb
+++ b/app/services/commands/look.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Commands
-  class LookCommand < Base
+  class Look < Base
     # Determine if the command is rendered immediately.
     #
     # @return [Boolean]

--- a/app/services/commands/move.rb
+++ b/app/services/commands/move.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Commands
-  class MoveCommand < Base
+  class Move < Base
     OFFSETS = {
       down:  { z: -1 },
       east:  { x:  1 },

--- a/app/services/commands/say.rb
+++ b/app/services/commands/say.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Commands
-  class SayCommand < Base
+  class Say < Base
     # Broadcast a say command to chat.
     def call
       if valid?

--- a/app/services/commands/unknown.rb
+++ b/app/services/commands/unknown.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Commands
-  class UnknownCommand < Base
+  class Unknown < Base
     # Determine if the command is rendered immediately.
     #
     # @return [Boolean]

--- a/app/services/commands/whisper.rb
+++ b/app/services/commands/whisper.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 module Commands
-  class DirectCommand < Base
-    # Broadcast a direct command to chat.
+  class Whisper < Base
+    # Broadcast a whisper command to the target.
     def call
       if valid?
-        broadcast_append_later_to(character.room_gid, target: "messages")
+        broadcast_append_later_to(target, target: "messages")
       end
     end
 
@@ -13,7 +13,7 @@ module Commands
     #
     # @return [Boolean]
     def rendered?
-      !valid? && message.present?
+      true
     end
 
     private
@@ -30,7 +30,7 @@ module Commands
       }
     end
 
-    # Return the message being directed to the target.
+    # Return the message being whispered to the target.
     #
     # @return [String]
     def message

--- a/config/initializers/throttling.rb
+++ b/config/initializers/throttling.rb
@@ -19,7 +19,7 @@ Rack::Attack.throttle(
 
     [
       request.session["account_id"],
-      command.name.demodulize.delete_suffix(Commands::Base::SUFFIX)
+      command.name.delete_prefix("Commands::").underscore
     ].join("/")
   end
 end

--- a/spec/controllers/commands_controller_spec.rb
+++ b/spec/controllers/commands_controller_spec.rb
@@ -10,7 +10,7 @@ describe CommandsController do
       let(:raw_input)   { "  Hello,  world!  " }
 
       let(:command) do
-        instance_double(Commands::UnknownCommand, rendered?: false)
+        instance_double(Commands::Unknown, rendered?: false)
       end
 
       before do
@@ -24,7 +24,7 @@ describe CommandsController do
       context "with rendering" do
         let(:command) do
           instance_double(
-            Commands::UnknownCommand,
+            Commands::Unknown,
             rendered?:      true,
             render_options: {
               partial: "commands/unknown"

--- a/spec/lib/rack/attack_spec.rb
+++ b/spec/lib/rack/attack_spec.rb
@@ -54,7 +54,7 @@ describe Rack::Attack do
 
     context "with a POST to /commands" do
       let(:account_id) { rand }
-      let(:command)    { Commands::AttackCommand }
+      let(:command)    { stub_const("Commands::Test::Example", Class.new) }
       let(:input)      { double }
 
       let(:request) do
@@ -78,7 +78,7 @@ describe Rack::Attack do
         expect(request.env["miroha.command"]).to eq(command)
       end
 
-      it { is_expected.to eq("#{account_id}/Attack") }
+      it { is_expected.to eq("#{account_id}/test/example") }
     end
 
     context "with other requests" do

--- a/spec/services/command_spec.rb
+++ b/spec/services/command_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 describe Command, type: :service do
   describe ".call" do
     let(:character) { build_stubbed(:character) }
-    let(:command)   { Commands::SayCommand }
+    let(:command)   { Commands::Say }
     let(:instance)  { instance_double(command, call: true) }
     let(:input)     { "/say Hello!" }
 
@@ -45,19 +45,19 @@ describe Command, type: :service do
     context "with a known command" do
       let(:input) { "/attack Rat" }
 
-      it { is_expected.to eq(Commands::AttackCommand) }
+      it { is_expected.to eq(Commands::Attack) }
     end
 
     context "with an unknown command" do
       let(:input) { "/notareal command" }
 
-      it { is_expected.to eq(Commands::UnknownCommand) }
+      it { is_expected.to eq(Commands::Unknown) }
     end
 
     context "with no command" do
       let(:input) { "Hello, world!" }
 
-      it { is_expected.to eq(Commands::SayCommand) }
+      it { is_expected.to eq(Commands::Say) }
     end
   end
 end

--- a/spec/services/commands/alias_spec.rb
+++ b/spec/services/commands/alias_spec.rb
@@ -2,9 +2,9 @@
 
 require "rails_helper"
 
-describe Commands::HelpCommand, type: :service do
+describe Commands::Alias, type: :service do
   let(:character) { build_stubbed(:character) }
-  let(:instance)  { described_class.new("/help", character: character) }
+  let(:instance)  { described_class.new("/alias", character: character) }
 
   describe "#call" do
     subject(:call) { instance.call }
@@ -33,24 +33,11 @@ describe Commands::HelpCommand, type: :service do
   describe "#render_options" do
     subject(:render_options) { instance.render_options }
 
-    let(:command)      { { arguments: "[test]", description: "Testing.", name: "example" } }
-    let(:translations) { { example: { arguments: "[test]", description: "Testing." } } }
-
-    before do
-      allow(I18n).to receive(:t).with("commands.help.commands").and_return(translations)
-
-      described_class.instance_variable_set(:@commands, nil)
-    end
-
-    after do
-      described_class.instance_variable_set(:@commands, nil)
-    end
-
-    it "returns the partial with command locals" do
+    it "returns the partial with aliases locals" do
       expect(render_options).to eq(
-        partial: "commands/help",
+        partial: "commands/alias",
         locals:  {
-          commands: [command]
+          aliases: character.account.aliases
         }
       )
     end

--- a/spec/services/commands/attack_spec.rb
+++ b/spec/services/commands/attack_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe Commands::AttackCommand, type: :service do
+describe Commands::Attack, type: :service do
   let(:character) { create(:character, room: spawn.room) }
   let(:damage)    { 1 }
   let(:instance)  { described_class.new("/attack #{target.name}", character: character) }

--- a/spec/services/commands/direct_spec.rb
+++ b/spec/services/commands/direct_spec.rb
@@ -2,9 +2,9 @@
 
 require "rails_helper"
 
-describe Commands::WhisperCommand, type: :service do
+describe Commands::Direct, type: :service do
   let(:character)   { create(:character) }
-  let(:instance)    { described_class.new("/whisper #{target_name} #{message}", character: character) }
+  let(:instance)    { described_class.new("/direct #{target_name} #{message}", character: character) }
   let(:message)     { "Hello." }
   let(:target)      { create(:character, room: character.room) }
   let(:target_name) { target.name.upcase }
@@ -17,14 +17,14 @@ describe Commands::WhisperCommand, type: :service do
     end
 
     context "with a valid target" do
-      it "broadcasts whisper partial to the target" do
+      it "broadcasts direct partial to the room" do
         call
 
         expect(Turbo::StreamsChannel).to have_received(:broadcast_append_later_to)
           .with(
-            target,
+            character.room_gid,
             target:  "messages",
-            partial: "commands/whisper",
+            partial: "commands/direct",
             locals:  {
               character:   character,
               message:     message,
@@ -90,7 +90,7 @@ describe Commands::WhisperCommand, type: :service do
     subject(:rendered?) { instance.rendered? }
 
     context "with a valid target" do
-      it { is_expected.to be(true) }
+      it { is_expected.to be(false) }
     end
 
     context "with character as target" do
@@ -108,7 +108,7 @@ describe Commands::WhisperCommand, type: :service do
     context "with blank message" do
       let(:message) { " " }
 
-      it { is_expected.to be(true) }
+      it { is_expected.to be(false) }
     end
   end
 
@@ -117,7 +117,7 @@ describe Commands::WhisperCommand, type: :service do
 
     it "returns the partial with character and message locals" do
       expect(render_options).to eq(
-        partial: "commands/whisper",
+        partial: "commands/direct",
         locals:  {
           character:   character,
           message:     message,

--- a/spec/services/commands/help_spec.rb
+++ b/spec/services/commands/help_spec.rb
@@ -2,9 +2,9 @@
 
 require "rails_helper"
 
-describe Commands::AliasCommand, type: :service do
+describe Commands::Help, type: :service do
   let(:character) { build_stubbed(:character) }
-  let(:instance)  { described_class.new("/alias", character: character) }
+  let(:instance)  { described_class.new("/help", character: character) }
 
   describe "#call" do
     subject(:call) { instance.call }
@@ -33,11 +33,24 @@ describe Commands::AliasCommand, type: :service do
   describe "#render_options" do
     subject(:render_options) { instance.render_options }
 
-    it "returns the partial with aliases locals" do
+    let(:command)      { { arguments: "[test]", description: "Testing.", name: "example" } }
+    let(:translations) { { example: { arguments: "[test]", description: "Testing." } } }
+
+    before do
+      allow(I18n).to receive(:t).with("commands.help.commands").and_return(translations)
+
+      described_class.instance_variable_set(:@commands, nil)
+    end
+
+    after do
+      described_class.instance_variable_set(:@commands, nil)
+    end
+
+    it "returns the partial with command locals" do
       expect(render_options).to eq(
-        partial: "commands/alias",
+        partial: "commands/help",
         locals:  {
-          aliases: character.account.aliases
+          commands: [command]
         }
       )
     end

--- a/spec/services/commands/look_spec.rb
+++ b/spec/services/commands/look_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe Commands::LookCommand, type: :service do
+describe Commands::Look, type: :service do
   let(:character) { build_stubbed(:character, room: room) }
   let(:object)    { nil }
   let(:room)      { build_stubbed(:room) }

--- a/spec/services/commands/move_spec.rb
+++ b/spec/services/commands/move_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe Commands::MoveCommand, type: :service do
+describe Commands::Move, type: :service do
   let(:character) { create(:character, room: room) }
   let(:instance)  { described_class.new("/move #{direction}", character: character) }
   let(:room)      { create(:room, origin) }

--- a/spec/services/commands/unknown_spec.rb
+++ b/spec/services/commands/unknown_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe Commands::UnknownCommand, type: :service do
+describe Commands::Unknown, type: :service do
   let(:character) { build_stubbed(:character) }
   let(:instance)  { described_class.new("/unknown", character: character) }
 

--- a/spec/services/commands/whisper_spec.rb
+++ b/spec/services/commands/whisper_spec.rb
@@ -2,9 +2,9 @@
 
 require "rails_helper"
 
-describe Commands::DirectCommand, type: :service do
+describe Commands::Whisper, type: :service do
   let(:character)   { create(:character) }
-  let(:instance)    { described_class.new("/direct #{target_name} #{message}", character: character) }
+  let(:instance)    { described_class.new("/whisper #{target_name} #{message}", character: character) }
   let(:message)     { "Hello." }
   let(:target)      { create(:character, room: character.room) }
   let(:target_name) { target.name.upcase }
@@ -17,14 +17,14 @@ describe Commands::DirectCommand, type: :service do
     end
 
     context "with a valid target" do
-      it "broadcasts direct partial to the room" do
+      it "broadcasts whisper partial to the target" do
         call
 
         expect(Turbo::StreamsChannel).to have_received(:broadcast_append_later_to)
           .with(
-            character.room_gid,
+            target,
             target:  "messages",
-            partial: "commands/direct",
+            partial: "commands/whisper",
             locals:  {
               character:   character,
               message:     message,
@@ -90,7 +90,7 @@ describe Commands::DirectCommand, type: :service do
     subject(:rendered?) { instance.rendered? }
 
     context "with a valid target" do
-      it { is_expected.to be(false) }
+      it { is_expected.to be(true) }
     end
 
     context "with character as target" do
@@ -108,7 +108,7 @@ describe Commands::DirectCommand, type: :service do
     context "with blank message" do
       let(:message) { " " }
 
-      it { is_expected.to be(false) }
+      it { is_expected.to be(true) }
     end
   end
 
@@ -117,7 +117,7 @@ describe Commands::DirectCommand, type: :service do
 
     it "returns the partial with character and message locals" do
       expect(render_options).to eq(
-        partial: "commands/direct",
+        partial: "commands/whisper",
         locals:  {
           character:   character,
           message:     message,


### PR DESCRIPTION
This is to prepare to allow nesting commands to better organize them, such as `Alias::List` and `Alias::Add`.