### PR TITLE
Improve and simplify the command name removal.

### DIFF
--- a/app/services/commands/base.rb
+++ b/app/services/commands/base.rb
@@ -74,7 +74,7 @@ module Commands
     #
     # @return [String]
     def input_without_command
-      @input_without_command ||= input.sub(%r{^/#{name}(\s+|\z)}, "")
+      @input_without_command ||= input.sub(%r{^/[a-z]+(\s+|\z)}i, "")
     end
 
     # Return the locals for the partial template.
@@ -82,16 +82,6 @@ module Commands
     # @return [Hash] The local variables.
     def locals
       {}
-    end
-
-    # Return the name of the command.
-    #
-    #     Commands::Say
-    #     # => "say"
-    #
-    # @return [String]
-    def name
-      @name ||= self.class.name.demodulize.downcase
     end
   end
 end

--- a/spec/services/commands/say_spec.rb
+++ b/spec/services/commands/say_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 describe Commands::Say, type: :service do
   let(:character) { build_stubbed(:character) }
-  let(:command)   { "/say #{message}" }
+  let(:command)   { "/Say #{message}" }
   let(:instance)  { described_class.new(command, character: character) }
 
   describe "#call" do


### PR DESCRIPTION
Don't need to be so specific for the replacement and it's not if it's not case-sensitive.