### PR TITLE
Ensure streams are connected in tests when signing a character in.

### DIFF
--- a/spec/support/helpers/session.rb
+++ b/spec/support/helpers/session.rb
@@ -30,7 +30,13 @@ module RSpec
         def sign_in_as_character(character = create(:character))
           visit root_path(account: character.account_id, character: character.id)
 
-          expect(page).to have_css("#sidebar h1", text: character.name)
+          expect(page).to have_css("#sidebar h1", text: character.name).and(
+            have_css(
+              "#streams turbo-cable-stream-source[connected]",
+              count:   2,
+              visible: :all
+            )
+          )
         end
 
         def sign_out


### PR DESCRIPTION
This seems to fix race conditions I would hit locally with events being sent to characters _before_ they were connected to the appropriate streams, resulting in sporadic test failures. Unclear why it never, or very rarely, appeared on CI though.