### PR TITLE
Switch to has_secure_password for the account password.

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -17,7 +17,7 @@ class Account < ApplicationRecord
   MAXIMUM_EMAIL_LENGTH    = 255
   MINIMUM_PASSWORD_LENGTH = 8
 
-  attr_reader :password
+  has_secure_password
 
   has_many :characters, dependent: :destroy
 
@@ -26,9 +26,7 @@ class Account < ApplicationRecord
                     format:     { with: EMAIL_MATCHER },
                     uniqueness: { case_sensitive: false }
 
-  validates :password, presence: true,
-                       length:   { minimum: MINIMUM_PASSWORD_LENGTH },
-                       if:       :password_required?
+  validates :password, length: { minimum: MINIMUM_PASSWORD_LENGTH }
 
   before_validation :format_attributes
   before_create     :assign_default_aliases
@@ -38,17 +36,6 @@ class Account < ApplicationRecord
   # @return [Boolean]
   def can_create_character?
     characters.size < CHARACTER_LIMIT
-  end
-
-  # Assign the provided password and create a digest when present.
-  #
-  # @return [void]
-  def password=(password)
-    @password = password
-
-    self.password_digest = if password.present?
-                             BCrypt::Password.create(password)
-                           end
   end
 
   protected
@@ -67,13 +54,5 @@ class Account < ApplicationRecord
   # @return [void]
   def format_attributes
     self.email = email.to_s.strip.downcase
-  end
-
-  # If the password digest is missing or a new password is present then the
-  # password requires validation.
-  #
-  # @return [Boolean]
-  def password_required?
-    password_digest.blank? || password.present?
   end
 end

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -61,36 +61,4 @@ describe Account do
       expect(account.email).to eq("an@example.com")
     end
   end
-
-  describe "#password=" do
-    subject(:account) { build(:account) }
-
-    let(:plain_text_password) { generate(:password) }
-
-    before do
-      allow(BCrypt::Password).to receive(:create)
-      allow(BCrypt::Password).to receive(:create)
-        .with(plain_text_password).and_return("hash")
-    end
-
-    it "assigns unencrypted password to password" do
-      account.password = plain_text_password
-
-      expect(account.password).to eq(plain_text_password)
-    end
-
-    it "assigns hashed password to password digest" do
-      account.password = plain_text_password
-
-      expect(account.password_digest).to eq(
-        BCrypt::Password.create(plain_text_password)
-      )
-    end
-
-    it "removes password digest when assigned nil" do
-      account.password = nil
-
-      expect(account.password_digest).to be_nil
-    end
-  end
 end


### PR DESCRIPTION
Slightly less code to maintain, but is also changes the BCrypt cost in the test environment significantly speeding up the entire test suite. Locally the full run goes from ~3 minutes to ~30 seconds.