### PR TITLE
Add a command to show a single alias.

### DIFF
--- a/app/services/commands/alias/show.rb
+++ b/app/services/commands/alias/show.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module Commands
+  module Alias
+    class Show < Base
+      argument alias_name: 2
+
+      # Determine if the argument matches this command.
+      #
+      # @return [Boolean]
+      def self.match?(arguments)
+        arguments.first == "show"
+      end
+
+      private
+
+      # Return the requested alias to show.
+      #
+      # @return [Hash]
+      def aliases
+        character.account.aliases.slice(parameters[:alias_name])
+      end
+
+      # Return the handler for a successful command execution.
+      #
+      # @return [Success]
+      def success
+        Success.new(aliases: aliases)
+      end
+
+      # Validate if the alias name exists.
+      #
+      # @return [Boolean] If the alias exists or not.
+      def validate_alias_name
+        if aliases.blank?
+          UnknownAlias.new(name: parameters[:alias_name])
+        end
+      end
+    end
+  end
+end

--- a/app/services/commands/alias/show.rb
+++ b/app/services/commands/alias/show.rb
@@ -3,7 +3,7 @@
 module Commands
   module Alias
     class Show < Base
-      argument alias_name: 2
+      argument alias_name: 0
 
       # Determine if the argument matches this command.
       #

--- a/app/services/commands/alias/show/success.rb
+++ b/app/services/commands/alias/show/success.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Commands
+  module Alias
+    class Show < Base
+      class Success < Result
+        locals :aliases
+
+        # Initialize a successful alias show result.
+        #
+        # @return [void]
+        def initialize(aliases:)
+          @aliases = aliases
+        end
+      end
+    end
+  end
+end

--- a/app/services/commands/alias/show/unknown_alias.rb
+++ b/app/services/commands/alias/show/unknown_alias.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Commands
+  module Alias
+    class Show < Base
+      class UnknownAlias < Result
+        locals :name
+
+        # Initialize an unknown alias show result.
+        #
+        # @return [void]
+        def initialize(name:)
+          @name = name
+        end
+      end
+    end
+  end
+end

--- a/app/services/commands/base.rb
+++ b/app/services/commands/base.rb
@@ -4,8 +4,8 @@ module Commands
   class Base
     extend Forwardable
 
+    PREFIX          = "Commands::"
     SPACES          = /\s+/
-    SUFFIX          = "Command"
     THROTTLE_LIMIT  = 10
     THROTTLE_PERIOD = 5
 
@@ -60,7 +60,7 @@ module Commands
     #
     # @return [Array]
     def arguments
-      @arguments ||= input.sub(%r{^/#{name}(\s+|\z)}i, "").split(SPACES)
+      @arguments ||= input.sub(%r{^/#{parts}(\s+|\z)}i, "").split(SPACES)
     end
 
     # Validate parameters and return the command handler.
@@ -70,16 +70,6 @@ module Commands
       @handler ||= validations.find(&:itself) || success
     end
 
-    # Return the name of the command.
-    #
-    #     Commands::SayCommand
-    #     # => "say"
-    #
-    # @return [String]
-    def name
-      @name ||= self.class.name.demodulize.delete_suffix(SUFFIX).downcase
-    end
-
     # Parse the arguments into position based parameters.
     #
     # @return [Hash]
@@ -87,6 +77,18 @@ module Commands
       @parameters ||= self.class.arguments.each.with_object({}) do |(name, position), result|
         result[name] = Array(arguments[position]).join(" ").presence
       end
+    end
+
+    # Return the parts of the command.
+    #
+    #     Commands::Say
+    #     # => "say"
+    #     Commands::Alias::List
+    #     # => "alias list"
+    #
+    # @return [String]
+    def parts
+      @parts ||= self.class.name.to_s.delete_prefix(PREFIX).gsub("::", " ").downcase
     end
 
     # Return a lazy enumerable to call possible validation for each parameter.

--- a/app/views/commands/alias/list/_success.html.erb
+++ b/app/views/commands/alias/list/_success.html.erb
@@ -2,7 +2,7 @@
   <td colspan="2" class="message-alias">
     <table>
       <tr>
-        <td colspan="2"><%= t(".header") %></td>
+        <td colspan="2"><%= t(".header", count: aliases.size) %></td>
       </tr>
 
       <% aliases.each do |(name, command)| %>

--- a/app/views/commands/alias/show/_success.turbo_stream.erb
+++ b/app/views/commands/alias/show/_success.turbo_stream.erb
@@ -1,0 +1,1 @@
+<%= turbo_stream.append("messages", partial: "commands/alias/list/success", locals: { aliases: aliases }) %>

--- a/app/views/commands/alias/show/_unknown_alias.html.erb
+++ b/app/views/commands/alias/show/_unknown_alias.html.erb
@@ -1,0 +1,6 @@
+<tr data-chat-target="message">
+  <td class="message-alias-unknown"></td>
+  <td class="message-alias-unknown">
+    <%= t(".message", name: name) %>
+  </td>
+</tr>

--- a/app/views/commands/alias/show/_unknown_alias.turbo_stream.erb
+++ b/app/views/commands/alias/show/_unknown_alias.turbo_stream.erb
@@ -1,0 +1,1 @@
+<%= turbo_stream.append("messages", partial: "commands/alias/show/unknown_alias", locals: { name: name }) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -64,7 +64,12 @@ en:
     alias:
       list:
         success:
-          header: "Command Aliases"
+          header:
+            one: "Command Alias"
+            other: "Command Aliases"
+      show:
+        unknown_alias:
+          message: "You do not have an alias for \"%{name}\"."
     attack:
       hit:
         message:

--- a/spec/features/commands/alias/show_spec.rb
+++ b/spec/features/commands/alias/show_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "Sending the alias show command", :js do
+  let(:character) { create(:character) }
+  let(:command)   { "/alias show u" }
+
+  before do
+    sign_in_as_character character
+  end
+
+  it "displays the alias show command message to the sender" do
+    send_text(command)
+
+    expect(page).to have_alias_command_message
+  end
+
+  it "does not broadcast the message to the room" do
+    using_session(:nearby_character) do
+      sign_in_as_character create(:character, room: character.room)
+    end
+
+    send_text(command)
+
+    wait_for(have_alias_command_message) do
+      using_session(:nearby_character) do
+        expect(page).not_to have_alias_command_message
+      end
+    end
+  end
+
+  context "with an unknown alias" do
+    let(:command) { "/alias show #{name}" }
+    let(:name)    { "unknown" }
+
+    it "displays unknown alias message to the sender" do
+      send_text(command)
+
+      expect(page).to have_unknown_alias_message(name: name)
+    end
+
+    it "does not broadcast the message to the room" do
+      using_session(:nearby_character) do
+        sign_in_as_character create(:character, room: character.room)
+      end
+
+      send_text(command)
+
+      wait_for(have_unknown_alias_message(name: name)) do
+        using_session(:nearby_character) do
+          expect(page).not_to have_unknown_alias_message(name: name)
+        end
+      end
+    end
+  end
+
+  protected
+
+  def have_alias_command_message
+    have_css("#messages .message-alias")
+  end
+
+  def have_unknown_alias_message(name:)
+    have_css(
+      "#messages .message-alias-unknown",
+      text: t("commands.alias.show.unknown_alias.message", name: name)
+    )
+  end
+end

--- a/spec/services/commands/alias/show/success_spec.rb
+++ b/spec/services/commands/alias/show/success_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe Commands::Alias::Show::Success, type: :service do
+  describe "class" do
+    it "inherits from command result" do
+      expect(described_class.superclass).to eq(Commands::Result)
+    end
+  end
+
+  describe "#locals" do
+    subject { instance.locals }
+
+    let(:aliases)  { { "u" => "/move up" } }
+    let(:instance) { described_class.new(aliases: aliases) }
+
+    it { is_expected.to eq(aliases: aliases) }
+  end
+end

--- a/spec/services/commands/alias/show/unknown_alias_spec.rb
+++ b/spec/services/commands/alias/show/unknown_alias_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe Commands::Alias::Show::UnknownAlias, type: :service do
+  describe "class" do
+    it "inherits from command result" do
+      expect(described_class.superclass).to eq(Commands::Result)
+    end
+  end
+
+  describe "#locals" do
+    subject { instance.locals }
+
+    let(:name)     { double }
+    let(:instance) { described_class.new(name: name) }
+
+    it { is_expected.to eq(name: name) }
+  end
+end

--- a/spec/services/commands/alias/show_spec.rb
+++ b/spec/services/commands/alias/show_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe Commands::Alias::Show, type: :service do
+  describe ".match?" do
+    subject { described_class.match?(arguments) }
+
+    context "with show argument" do
+      let(:arguments) { %w(show u) }
+
+      it { is_expected.to be(true) }
+    end
+
+    context "with no arguments" do
+      let(:arguments) { [] }
+
+      it { is_expected.to be(false) }
+    end
+
+    context "with other arguments" do
+      let(:arguments) { %w(fake list) }
+
+      it { is_expected.to be(false) }
+    end
+  end
+
+  describe "#call" do
+    subject(:call) { instance.call }
+
+    let(:account)   { build_stubbed(:account, aliases: aliases) }
+    let(:aliases)   { { "d" => "/move down", "u" => "/move up" } }
+    let(:character) { build_stubbed(:character, account: account) }
+
+    context "with a valid alias" do
+      let(:instance) { described_class.new("/alias show u", character: character) }
+      let(:result)   { instance_double(described_class::Success) }
+
+      before do
+        allow(result).to receive(:call)
+        allow(described_class::Success).to receive(:new)
+          .with(aliases: { "u" => "/move up" })
+          .and_return(result)
+      end
+
+      it "delegates to success handler" do
+        call
+
+        expect(result).to have_received(:call).with(no_args)
+      end
+    end
+
+    context "with an invalid alias" do
+      let(:instance) { described_class.new("/alias show x", character: character) }
+      let(:result)   { instance_double(described_class::UnknownAlias) }
+
+      before do
+        allow(result).to receive(:call)
+        allow(described_class::UnknownAlias).to receive(:new)
+          .with(name: "x")
+          .and_return(result)
+      end
+
+      it "delegates to unknown alias handler" do
+        call
+
+        expect(result).to have_received(:call).with(no_args)
+      end
+    end
+  end
+end

--- a/spec/views/commands/alias/list/_success.html.erb_spec.rb
+++ b/spec/views/commands/alias/list/_success.html.erb_spec.rb
@@ -19,7 +19,7 @@ describe "commands/alias/list/success.html.erb" do
   it "renders the header" do
     expect(html).to have_css(
       ".message-alias td[colspan=2]",
-      text: t("commands.alias.list.success.header")
+      text: t("commands.alias.list.success.header", count: 2)
     )
   end
 

--- a/spec/views/commands/alias/show/_success.turbo_stream.erb_spec.rb
+++ b/spec/views/commands/alias/show/_success.turbo_stream.erb_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "commands/alias/show/_success.turbo_stream.erb" do
+  subject(:html) do
+    render partial: "commands/alias/show/success",
+           formats: :turbo_stream,
+           locals:  { aliases: [] }
+
+    rendered
+  end
+
+  before do
+    stub_template("commands/alias/list/_success.html.erb" => "ALIAS_TEMPLATE")
+  end
+
+  it "appends to the messages element" do
+    expect(html).to have_turbo_stream_element(
+      action: "append",
+      target: "messages"
+    )
+  end
+
+  it "renders the HTML template" do
+    expect(html).to include("ALIAS_TEMPLATE")
+  end
+end

--- a/spec/views/commands/alias/show/_unknown_alias.html.erb_spec.rb
+++ b/spec/views/commands/alias/show/_unknown_alias.html.erb_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "commands/alias/show/_unknown_alias.html.erb" do
+  subject(:html) do
+    render partial: "commands/alias/show/unknown_alias",
+           locals:  { name: name }
+
+    rendered
+  end
+
+  let(:name) { "unknown" }
+
+  it "renders the invalid direction message" do
+    expect(html).to have_message_row(
+      "td:nth-child(2)",
+      text: t("commands.alias.show.unknown_alias.message", name: name)
+    )
+  end
+end

--- a/spec/views/commands/alias/show/_unknown_alias.turbo_stream.erb_spec.rb
+++ b/spec/views/commands/alias/show/_unknown_alias.turbo_stream.erb_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "commands/alias/show/_unknown_alias.turbo_stream.erb" do
+  subject(:html) do
+    render partial: "commands/alias/show/unknown_alias",
+           formats: :turbo_stream,
+           locals:  { name: "unknown" }
+
+    rendered
+  end
+
+  before do
+    stub_template("commands/alias/show/_unknown_alias.html.erb" => "UKNOWN_ALIAS_TEMPLATE")
+  end
+
+  it "appends to the messages element" do
+    expect(html).to have_turbo_stream_element(
+      action: "append",
+      target: "messages"
+    )
+  end
+
+  it "renders the HTML template" do
+    expect(html).to include("UKNOWN_ALIAS_TEMPLATE")
+  end
+end


### PR DESCRIPTION
Fixes #235.

Also improves how command parts are removed from arguments.