### PR TITLE
Switch from workflow to manual linting.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,16 +83,14 @@ jobs:
           cache: "yarn"
       - name: Install the Node dependencies
         run: yarn install
-      - name: Lint the code
-        uses: wearerequired/lint-action@v2
-        with:
-          ERBLINT: true
-          ERBLINT_COMMAND_PREFIX: bundle exec
-          ESLINT: true
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RUBOCOP: true
-          RUBOCOP_COMMAND_PREFIX: bundle exec
-          STYLELINT: true
+      - name: Lint the ERB
+        run: bundle exec erblint .
+      - name: Lint the Ruby
+        run: bundle exec rubocop --parallel
+      - name: Lint the JavaScript
+        run: yarn lint
+      - name: Lint the CSS
+        run: yarn lint:css
 
   Vulnerabilities:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The third-party GitHub Actions workflow is becoming outdated so switching back to manual linting. This loses the status check per linting, but it runs about a minute faster than the workflow.