### PR TITLE
Adjust profiler threshold minimum and position.

### DIFF
--- a/config/initializers/profiler.rb
+++ b/config/initializers/profiler.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+if defined?(Rack::MiniProfiler)
+  Rack::MiniProfiler.config.backtrace_threshold_ms = 0.1
+  Rack::MiniProfiler.config.position = "bottom-right"
+end


### PR DESCRIPTION
The threshold minimum helps avoid really fast queries and least relevant queries, such as `BEGIN`. And the position avoids overlapping the character sidebar when playing the game.