### PR TITLE
Only validate password length when present.

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -17,7 +17,7 @@ class Account < ApplicationRecord
                     format:     { with: EMAIL_MATCHER },
                     uniqueness: { case_sensitive: false }
 
-  validates :password, length: { minimum: MINIMUM_PASSWORD_LENGTH }
+  validates :password, length: { minimum: MINIMUM_PASSWORD_LENGTH, allow_blank: true }
 
   # Determine if an account can create a character.
   #

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -15,7 +15,7 @@ describe Account do
     it { is_expected.to allow_value("MrBoB@example.com").for(:email) }
     it { is_expected.not_to allow_value("@.com").for(:email) }
 
-    it { is_expected.to validate_presence_of(:password).on(:update) }
+    it { is_expected.to validate_presence_of(:password).allow_blank }
 
     it "is expected to validate that the length of :email is at most the maximum" do
       expect(account).to validate_length_of(:email)


### PR DESCRIPTION
Once a `password` is set it's stored in `password_digest` and will only ever be set again when present. Always validating it's present prevents an account from being updated unless the password is also being changed, so we allow for the password to be blank. And since `has_secure_password` requires a password to be present during creation, it's still not possible to create an account without a password.