### PR TITLE
Enable caching when a REDIS_URL is present.

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -20,7 +20,7 @@ Rails.application.configure do
   # Enable or disable caching. By default caching is disabled.
   #
   # Run rails dev:cache to toggle caching.
-  if Rails.root.join("tmp/caching-dev.txt").exist?
+  if ENV.key?("REDIS_URL") || Rails.root.join("tmp/caching-dev.txt").exist?
     config.action_controller.perform_caching = true
     config.action_controller.enable_fragment_cache_logging = true
 


### PR DESCRIPTION
This automatically enables caching when using Docker Compose, and provides an alternate method to enable it.