### PR TITLE
Switch to a text summary reporter for JavaScript test coverage.

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lint:css": "stylelint app/assets/stylesheets/**/*.css",
     "outdated": "yarn upgrade-interactive",
     "test": "bin/mocha spec/javascripts",
-    "test:coverage": "c8 --100 --clean --skip-full bin/mocha spec/javascripts"
+    "test:coverage": "c8 --100 --clean --reporter text-summary --skip-full bin/mocha spec/javascripts"
   },
   "dependencies": {
     "@hotwired/stimulus": "3.2.2",


### PR DESCRIPTION
The file list is nice when test coverage is missing, but when at 100% it's not very informative.

#### Before

```
$ yarn test:coverage


  ........................................................

  56 passing (176ms)

------------------------------------------|---------|----------|---------|---------|-------------------
File                                      | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
------------------------------------------|---------|----------|---------|---------|-------------------
------------------------------------------|---------|----------|---------|---------|-------------------
```

#### After

```
$ yarn test:coverage


  ........................................................

  56 passing (177ms)


=============================== Coverage summary ===============================
Statements   : 100% ( 1089/1089 )
Branches     : 100% ( 191/191 )
Functions    : 100% ( 24/24 )
Lines        : 100% ( 1089/1089 )
================================================================================
```