### PR TITLE
Improve the game character preloading.

### DIFF
--- a/app/controllers/game_controller.rb
+++ b/app/controllers/game_controller.rb
@@ -11,16 +11,19 @@ class GameController < ApplicationController
 
   # Render the game.
   def index
-    @account   = current_account
     @character = current_character
   end
 
   protected
 
-  # Override the current character helper to include other records.
+  # Override the character from session helper to include other records.
   #
   # @return [Character]
-  def current_character
-    @current_character ||= Character.includes(:room).find(session[:character_id])
+  def character_from_session
+    if session[:character_id].present?
+      Character
+        .includes(:account, room: %i(items monsters))
+        .find(session[:character_id])
+    end
   end
 end

--- a/app/views/game/index.html.erb
+++ b/app/views/game/index.html.erb
@@ -13,7 +13,7 @@
   <script>
     window.Miroha = {
       Settings: {
-        aliases: <%== @account.aliases.to_json %>
+        aliases: <%== @character.account.aliases.to_json %>
       }
     };
   </script>

--- a/spec/controllers/game_controller_spec.rb
+++ b/spec/controllers/game_controller_spec.rb
@@ -16,10 +16,6 @@ describe GameController do
       it { is_expected.to respond_with(200) }
       it { is_expected.to render_template("game/index", layout: "game") }
 
-      it "assigns the current account" do
-        expect(assigns(:account)).to eq(character.account)
-      end
-
       it "assigns the current character" do
         expect(assigns(:character)).to eq(character)
       end
@@ -39,10 +35,22 @@ describe GameController do
 
     context "with an invalid character ID" do
       before do
+        sign_in
+
+        session[:character_id] = 0
+
         get :index
       end
 
       it { is_expected.to redirect_to(characters_url) }
+    end
+
+    context "when signed out" do
+      before do
+        get :index
+      end
+
+      it { is_expected.to redirect_to(new_sessions_url) }
     end
   end
 end


### PR DESCRIPTION
- Includes the account, items, and monsters when finding the character.
- Switches from `current_character` to `character_from_session` to avoid needing to access the query cache every time `current_character` is accessed.