### PR TITLE
Disable parallelization for Bootsnap in Docker.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,13 +38,13 @@ RUN bundle install
 RUN rm -rf ~/.bundle/ "${BUNDLE_PATH}"/ruby/*/cache "${BUNDLE_PATH}"/ruby/*/bundler/gems/*/.git
 
 # Precompile the Bootsnap cache for the dependencies.
-RUN bundle exec bootsnap precompile --gemfile
+RUN bundle exec bootsnap precompile --gemfile --jobs 0
 
 # Copy the application into Docker.
 COPY . .
 
 # Precompile the Bootsnap cache for the application.
-RUN bundle exec bootsnap precompile app/ lib/
+RUN bundle exec bootsnap precompile --jobs 0 app/ lib/
 
 # Compile the assets without requiring the secret RAILS_MASTER_KEY.
 RUN SECRET_KEY_BASE_DUMMY=1 bundle exec rails assets:precompile


### PR DESCRIPTION
When building cross-platform builds Bootsnap was occasionally hanging. While the recommendation is for QEMU-based environments and I'm not using one, it still consistently avoids the issue.